### PR TITLE
Sign note to signer module

### DIFF
--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -41,14 +41,18 @@ signer.generateZKAssetDomainParams = (verifyingContract) => {
 
 /**
  * Create an EIP712 ECDSA signature over an AZTEC note, for a ZkAsset.sol domain
- * @method signNoteZkAssetDomain
+ *
+ * This is expected to be the default signNote() function. However for use cases, such as
+ * testing, where ACE domain params are required then the signNoteACEDomain() function is
+ * available.
+ * @method signNote
  * @param {string} verifyingContract address of target contract
  * @param {string} noteHash noteHash of the note being signed
  * @param {string} spender address of the note spender
  * @param {string} privateKey the private key of message signer
  * @returns {string[]} ECDSA signature parameters [v, r, s], formatted as 32-byte wide hex-strings
  */
-signer.signNoteZkAssetDomain = (validatorAddress, noteHash, spender, privateKey) => {
+signer.signNote = (validatorAddress, noteHash, spender, privateKey) => {
     const domain = signer.generateZKAssetDomainParams(validatorAddress);
     const schema = constants.eip712.NOTE_SIGNATURE;
     const status = true;

--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -14,11 +14,11 @@ const signer = {};
 
 /**
  * Generate EIP712 domain parameters for ACE.sol
- * @method generateAZTECDomainParams
+ * @method generateACEDomainParams
  * @param {string} verifyingContract address of target contract
  * @returns {Object} EIP712 Domain type object
  */
-signer.generateAZTECDomainParams = (verifyingContract, domain = constants.eip712.ACE_DOMAIN_PARAMS) => {
+signer.generateACEDomainParams = (verifyingContract, domain = constants.eip712.ACE_DOMAIN_PARAMS) => {
     return {
         name: domain.name,
         version: domain.version,
@@ -40,9 +40,10 @@ signer.generateZKAssetDomainParams = (verifyingContract) => {
 };
 
 /**
- * Create an EIP712 ECDSA signature over an AZTEC note, for a ZkAsset domain
+ * Create an EIP712 ECDSA signature over an AZTEC note, for a ZkAsset.sol domain
  * @method signNoteZkAssetDomain
  * @param {string} verifyingContract address of target contract
+ * @param {string} noteHash noteHash of the note being signed
  * @param {string} spender address of the note spender
  * @param {string} privateKey the private key of message signer
  * @returns {string[]} ECDSA signature parameters [v, r, s], formatted as 32-byte wide hex-strings
@@ -60,16 +61,16 @@ signer.signNoteZkAssetDomain = (validatorAddress, noteHash, spender, privateKey)
 };
 
 /**
- * Create an EIP712 ECDSA signature over an AZTEC note, 
- * @method signNoteAZTECDomain
+ * Create an EIP712 ECDSA signature over an AZTEC note, for an ACE.sol domain
+ * @method signNoteACEDomain
  * @param {string} verifyingContract address of target contract
  * @param {string} spender address of the note spender
  * @param {string} privateKey the private key of message signer
  * @returns {string[]} ECDSA signature parameters [v, r, s], formatted as 32-byte wide hex-strings
  */
 
-signer.signNoteAZTECDomain = (verifyingContract, spender, privateKey) => {
-    const domain = signer.generateAZTECDomainParams(verifyingContract, constants.eip712.ACE_DOMAIN_PARAMS);
+signer.signNoteACEDomain = (verifyingContract, spender, privateKey) => {
+    const domain = signer.generateACEDomainParams(verifyingContract, constants.eip712.ACE_DOMAIN_PARAMS);
     const schema = constants.eip712.NOTE_SIGNATURE;
     const status = true;
 
@@ -80,8 +81,6 @@ signer.signNoteAZTECDomain = (verifyingContract, spender, privateKey) => {
     };
     return signer.signTypedData(domain, schema, message, privateKey);
 };
-
-
 
 /**
  * Create an EIP712 ECDSA signature over structured data
@@ -99,7 +98,10 @@ signer.signTypedData = (domain, schema, message, privateKey) => {
         message,
     });
     const signature = secp256k1.ecdsa.signMessage(encodedTypedData, privateKey);
-    return { signature, encodedTypedData };
+    return {
+        signature,
+        encodedTypedData,
+    };
 };
 
 module.exports = signer;

--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -8,6 +8,7 @@
 const { constants } = require('@aztec/dev-utils');
 const secp256k1 = require('@aztec/secp256k1');
 const typedData = require('@aztec/typed-data');
+const crypto = require('crypto');
 
 const signer = {};
 
@@ -37,25 +38,50 @@ signer.generateZKAssetDomainParams = (verifyingContract) => {
         verifyingContract,
     };
 };
+
 /**
- * Create an EIP712 ECDSA signature over an AZTEC note
- * @method signNote
+ * Create an EIP712 ECDSA signature over an AZTEC note, for a ZkAsset domain
+ * @method signNoteZkAssetDomain
  * @param {string} verifyingContract address of target contract
  * @param {string} spender address of the note spender
  * @param {string} privateKey the private key of message signer
  * @returns {string[]} ECDSA signature parameters [v, r, s], formatted as 32-byte wide hex-strings
  */
-signer.signNote = (verifyingContract, spender, privateKey) => {
+signer.signNoteZkAssetDomain = (validatorAddress, noteHash, spender, privateKey) => {
+    const domain = signer.generateZKAssetDomainParams(validatorAddress);
+    const schema = constants.eip712.NOTE_SIGNATURE;
+    const status = true;
+    const message = {
+        noteHash,
+        spender,
+        status,
+    };
+    return signer.signTypedData(domain, schema, message, privateKey);
+};
+
+/**
+ * Create an EIP712 ECDSA signature over an AZTEC note, 
+ * @method signNoteAZTECDomain
+ * @param {string} verifyingContract address of target contract
+ * @param {string} spender address of the note spender
+ * @param {string} privateKey the private key of message signer
+ * @returns {string[]} ECDSA signature parameters [v, r, s], formatted as 32-byte wide hex-strings
+ */
+
+signer.signNoteAZTECDomain = (verifyingContract, spender, privateKey) => {
     const domain = signer.generateAZTECDomainParams(verifyingContract, constants.eip712.ACE_DOMAIN_PARAMS);
     const schema = constants.eip712.NOTE_SIGNATURE;
+    const status = true;
 
     const message = {
         noteHash: `0x${crypto.randomBytes(32).toString('hex')}`,
         spender,
-        status: true,
+        status,
     };
     return signer.signTypedData(domain, schema, message, privateKey);
 };
+
+
 
 /**
  * Create an EIP712 ECDSA signature over structured data

--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -37,6 +37,25 @@ signer.generateZKAssetDomainParams = (verifyingContract) => {
         verifyingContract,
     };
 };
+/**
+ * Create an EIP712 ECDSA signature over an AZTEC note 
+ * @method signNote
+ * @param {string} verifyingContract address of target contract
+ * @param {string} spender address of the note spender
+ * @param {string} privateKey the private key of message signer
+ * @returns {string[]} ECDSA signature parameters [v, r, s], formatted as 32-byte wide hex-strings
+ */
+signer.signNote = (verifyingContract, spender, privateKey) => {
+    const domain = signer.generateAZTECDomainParams(verifyingContract, constants.eip712.ACE_DOMAIN_PARAMS);
+    const schema = constants.eip712.NOTE_SIGNATURE;
+
+    const message = {
+        noteHash: `0x${crypto.randomBytes(32).toString('hex')}`,
+        spender,
+        status: true,
+    };
+    return signer.signTypedData(domain, schema, message, privateKey);
+};
 
 /**
  * Create an EIP712 ECDSA signature over structured data

--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -38,7 +38,7 @@ signer.generateZKAssetDomainParams = (verifyingContract) => {
     };
 };
 /**
- * Create an EIP712 ECDSA signature over an AZTEC note 
+ * Create an EIP712 ECDSA signature over an AZTEC note
  * @method signNote
  * @param {string} verifyingContract address of target contract
  * @param {string} spender address of the note spender

--- a/packages/aztec.js/test/signer/signer.js
+++ b/packages/aztec.js/test/signer/signer.js
@@ -26,7 +26,7 @@ describe('Signer', () => {
     });
 
     it('should generate correct AZTEC domain params', () => {
-        expect(signer.generateAZTECDomainParams('0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC')).to.deep.equal({
+        expect(signer.generateACEDomainParams('0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC')).to.deep.equal({
             name: 'AZTEC_CRYPTOGRAPHY_ENGINE',
             version: '1',
             verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
@@ -34,7 +34,7 @@ describe('Signer', () => {
     });
 
     it('should have the domain params resolve to expected message', () => {
-        const messageInput = signer.generateAZTECDomainParams('0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC');
+        const messageInput = signer.generateACEDomainParams('0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC');
         const result = typedData.encodeMessageData(domainTypes, 'EIP712Domain', messageInput);
         const messageData = [
             keccak256('EIP712Domain(string name,string version,address verifyingContract)').slice(2),
@@ -54,7 +54,7 @@ describe('Signer', () => {
             const challengeString = `${senderAddress}${padLeft('132', 64)}${padLeft('1', 64)}${[...noteString]}`;
             const challenge = `0x${new BN(keccak256(challengeString, 'hex').slice(2), 16).umod(bn128.curve.n).toString(16)}`;
 
-            const domain = signer.generateAZTECDomainParams(verifyingContract, constants.eip712.ACE_DOMAIN_PARAMS);
+            const domain = signer.generateACEDomainParams(verifyingContract, constants.eip712.ACE_DOMAIN_PARAMS);
             const schema = constants.eip712.JOIN_SPLIT_SIGNATURE;
             const message = {
                 proof: proofs.JOIN_SPLIT_PROOF,
@@ -81,7 +81,7 @@ describe('Signer', () => {
             const challengeString = `${senderAddress}${padLeft('132', 64)}${padLeft('1', 64)}${[...noteString]}`;
             const challenge = `0x${new BN(keccak256(challengeString, 'hex').slice(2), 16).umod(bn128.curve.n).toString(16)}`;
 
-            const domain = signer.generateAZTECDomainParams(verifyingContract, constants.eip712.ACE_DOMAIN_PARAMS);
+            const domain = signer.generateACEDomainParams(verifyingContract, constants.eip712.ACE_DOMAIN_PARAMS);
             const schema = constants.eip712.JOIN_SPLIT_SIGNATURE;
             const message = {
                 proof: proofs.JOIN_SPLIT_PROOF,

--- a/packages/protocol/test/ERC1724/ZkAssetOwnable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetOwnable.js
@@ -23,7 +23,7 @@ const ZkAssetOwnableTest = artifacts.require('./ZkAssetOwnableTest');
 
 JoinSplit.abi = JoinSplitInterface.abi;
 
-contract.only('ZkAssetOwnable', (accounts) => {
+contract('ZkAssetOwnable', (accounts) => {
     let ace;
     let aztecJoinSplit;
     let erc20;
@@ -38,7 +38,7 @@ contract.only('ZkAssetOwnable', (accounts) => {
     const confidentialApprove = async (indexes, notes, aztecAccounts) => {
         await Promise.all(
             indexes.map((i) => {
-                const { signature } = signer.signNoteZkAssetDomain(
+                const { signature } = signer.signNote(
                     zkAssetOwnable.address,
                     notes[i].noteHash,
                     zkAssetOwnableTest.address,
@@ -57,7 +57,9 @@ contract.only('ZkAssetOwnable', (accounts) => {
     };
 
     beforeEach(async () => {
-        ace = await ACE.new({ from: accounts[0] });
+        ace = await ACE.new({
+            from: accounts[0],
+        });
 
         await ace.setCommonReferenceString(constants.CRS);
         aztecJoinSplit = await JoinSplit.new();
@@ -73,13 +75,19 @@ contract.only('ZkAssetOwnable', (accounts) => {
 
         await Promise.all(
             accounts.map((account) => {
-                const opts = { from: accounts[0], gas: 4700000 };
+                const opts = {
+                    from: accounts[0],
+                    gas: 4700000,
+                };
                 return erc20.mint(account, scalingFactor.mul(tokensTransferred), opts);
             }),
         );
         await Promise.all(
             accounts.map((account) => {
-                const opts = { from: account, gas: 4700000 };
+                const opts = {
+                    from: account,
+                    gas: 4700000,
+                };
                 return erc20.approve(ace.address, scalingFactor.mul(tokensTransferred), opts);
             }),
         );
@@ -108,7 +116,9 @@ contract.only('ZkAssetOwnable', (accounts) => {
             });
             const depositProofOutput = outputCoder.getProofOutput(depositProof.expectedOutput, 0);
             const depositProofHash = outputCoder.hashProofOutput(depositProofOutput);
-            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 10, { from: accounts[0] });
+            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 10, {
+                from: accounts[0],
+            });
             await zkAssetOwnable.confidentialTransfer(depositProof.proofData, depositProof.signatures);
 
             const transferProof = proof.joinSplit.encodeJoinSplitTransaction({
@@ -122,7 +132,9 @@ contract.only('ZkAssetOwnable', (accounts) => {
             });
             const transferProofOutput = outputCoder.getProofOutput(transferProof.expectedOutput, 0);
             const transferProofHash = outputCoder.hashProofOutput(transferProofOutput);
-            await ace.publicApprove(zkAssetOwnable.address, transferProofHash, 40, { from: accounts[1] });
+            await ace.publicApprove(zkAssetOwnable.address, transferProofHash, 40, {
+                from: accounts[1],
+            });
 
             await confidentialApprove([0, 1], notes, aztecAccounts);
 
@@ -150,7 +162,9 @@ contract.only('ZkAssetOwnable', (accounts) => {
             });
             const depositProofOutput = outputCoder.getProofOutput(depositProof.expectedOutput, 0);
             const depositProofHash = outputCoder.hashProofOutput(depositProofOutput);
-            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 130, { from: accounts[0] });
+            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 130, {
+                from: accounts[0],
+            });
             await zkAssetOwnable.confidentialTransfer(depositProof.proofData, depositProof.signatures);
 
             const transferProof = proof.joinSplit.encodeJoinSplitTransaction({
@@ -194,7 +208,9 @@ contract.only('ZkAssetOwnable', (accounts) => {
             });
             const depositProofOutput = outputCoder.getProofOutput(depositProof.expectedOutput, 0);
             const depositProofHash = outputCoder.hashProofOutput(depositProofOutput);
-            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 30, { from: accounts[0] });
+            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 30, {
+                from: accounts[0],
+            });
             await zkAssetOwnable.confidentialTransfer(depositProof.proofData, depositProof.signatures);
 
             const transferProof = proof.joinSplit.encodeJoinSplitTransaction({
@@ -219,7 +235,9 @@ contract.only('ZkAssetOwnable', (accounts) => {
 
     describe('Failure States', async () => {
         it('should fail to set a new proof bit filter if not owner', async () => {
-            const opts = { from: accounts[1] };
+            const opts = {
+                from: accounts[1],
+            };
             await truffleAssert.reverts(zkAssetOwnable.setProofs(epoch, filter, opts), 'only the owner can set the epoch proofs');
         });
 
@@ -240,10 +258,12 @@ contract.only('ZkAssetOwnable', (accounts) => {
             });
             const depositProofOutput = outputCoder.getProofOutput(depositProof.expectedOutput, 0);
             const depositProofHash = outputCoder.hashProofOutput(depositProofOutput);
-            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 30, { from: accounts[0] });
+            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 30, {
+                from: accounts[0],
+            });
             await zkAssetOwnable.confidentialTransfer(depositProof.proofData, depositProof.signatures);
 
-            const { signature } = signer.signNoteZkAssetDomain(
+            const { signature } = signer.signNote(
                 zkAssetOwnable.address,
                 notes[0].noteHash,
                 zkAssetOwnableTest.address,
@@ -278,7 +298,9 @@ contract.only('ZkAssetOwnable', (accounts) => {
             });
             const depositProofOutput = outputCoder.getProofOutput(depositProof.expectedOutput, 0);
             const depositProofHash = outputCoder.hashProofOutput(depositProofOutput);
-            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 10, { from: accounts[0] });
+            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 10, {
+                from: accounts[0],
+            });
 
             const transferProof = proof.joinSplit.encodeJoinSplitTransaction({
                 inputNotes: notes.slice(0, 2),
@@ -291,12 +313,14 @@ contract.only('ZkAssetOwnable', (accounts) => {
             });
             const transferProofOutput = outputCoder.getProofOutput(transferProof.expectedOutput, 0);
             const transferProofHash = outputCoder.hashProofOutput(transferProofOutput);
-            await ace.publicApprove(zkAssetOwnable.address, transferProofHash, 40, { from: accounts[1] });
+            await ace.publicApprove(zkAssetOwnable.address, transferProofHash, 40, {
+                from: accounts[1],
+            });
 
             await zkAssetOwnable.confidentialTransfer(depositProof.proofData, depositProof.signatures);
             await zkAssetOwnable.confidentialTransfer(transferProof.proofData, transferProof.signatures);
 
-            const { signature } = signer.signNoteZkAssetDomain(
+            const { signature } = signer.signNote(
                 zkAssetOwnable.address,
                 notes[0].noteHash,
                 zkAssetOwnableTest.address,
@@ -327,7 +351,9 @@ contract.only('ZkAssetOwnable', (accounts) => {
             });
             const depositProofOutput = outputCoder.getProofOutput(depositProof.expectedOutput, 0);
             const depositProofHash = outputCoder.hashProofOutput(depositProofOutput);
-            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 10, { from: accounts[0] });
+            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 10, {
+                from: accounts[0],
+            });
 
             await zkAssetOwnable.confidentialTransfer(depositProof.proofData, depositProof.signatures);
 
@@ -355,7 +381,9 @@ contract.only('ZkAssetOwnable', (accounts) => {
             });
             const depositProofOutput = outputCoder.getProofOutput(depositProof.expectedOutput, 0);
             const depositProofHash = outputCoder.hashProofOutput(depositProofOutput);
-            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 10, { from: accounts[0] });
+            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 10, {
+                from: accounts[0],
+            });
 
             await zkAssetOwnable.confidentialTransfer(depositProof.proofData, depositProof.signatures);
 
@@ -370,7 +398,9 @@ contract.only('ZkAssetOwnable', (accounts) => {
             });
             const transferProofOutput = outputCoder.getProofOutput(transferProof.expectedOutput, 0);
             const transferProofHash = outputCoder.hashProofOutput(transferProofOutput);
-            await ace.publicApprove(zkAssetOwnable.address, transferProofHash, 40, { from: accounts[1] });
+            await ace.publicApprove(zkAssetOwnable.address, transferProofHash, 40, {
+                from: accounts[1],
+            });
 
             await confidentialApprove([0, 1], notes, aztecAccounts);
             await zkAssetOwnableTest.callValidateProof(JOIN_SPLIT_PROOF, transferProof.proofData);
@@ -400,7 +430,9 @@ contract.only('ZkAssetOwnable', (accounts) => {
             });
             const depositProofOutput = outputCoder.getProofOutput(depositProof.expectedOutput, 0);
             const depositProofHash = outputCoder.hashProofOutput(depositProofOutput);
-            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 10, { from: accounts[0] });
+            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 10, {
+                from: accounts[0],
+            });
             await zkAssetOwnable.confidentialTransfer(depositProof.proofData, depositProof.signatures);
 
             const transferProof = proof.joinSplit.encodeJoinSplitTransaction({
@@ -414,11 +446,15 @@ contract.only('ZkAssetOwnable', (accounts) => {
             });
             const transferProofOutput = outputCoder.getProofOutput(transferProof.expectedOutput, 0);
             const transferProofHash = outputCoder.hashProofOutput(transferProofOutput);
-            await ace.publicApprove(zkAssetOwnable.address, transferProofHash, 40, { from: accounts[1] });
+            await ace.publicApprove(zkAssetOwnable.address, transferProofHash, 40, {
+                from: accounts[1],
+            });
 
             await confidentialApprove([0, 1], notes, aztecAccounts);
 
-            const opts = { from: accounts[1] };
+            const opts = {
+                from: accounts[1],
+            };
             await ace.publicApprove(zkAssetOwnable.address, transferProofHash, 0, opts);
 
             await zkAssetOwnableTest.callValidateProof(JOIN_SPLIT_PROOF, transferProof.proofData);
@@ -447,7 +483,9 @@ contract.only('ZkAssetOwnable', (accounts) => {
             });
             const depositProofOutput = outputCoder.getProofOutput(depositProof.expectedOutput, 0);
             const depositProofHash = outputCoder.hashProofOutput(depositProofOutput);
-            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 10, { from: accounts[0] });
+            await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 10, {
+                from: accounts[0],
+            });
             await zkAssetOwnable.confidentialTransfer(depositProof.proofData, depositProof.signatures);
 
             const transferProof = proof.joinSplit.encodeJoinSplitTransaction({
@@ -461,11 +499,15 @@ contract.only('ZkAssetOwnable', (accounts) => {
             });
             const transferProofOutput = outputCoder.getProofOutput(transferProof.expectedOutput, 0);
             const transferProofHash = outputCoder.hashProofOutput(transferProofOutput);
-            await ace.publicApprove(zkAssetOwnable.address, transferProofHash, 40, { from: accounts[1] });
+            await ace.publicApprove(zkAssetOwnable.address, transferProofHash, 40, {
+                from: accounts[1],
+            });
 
             // No confidentialApprove() call
 
-            const opts = { from: accounts[1] };
+            const opts = {
+                from: accounts[1],
+            };
             await ace.publicApprove(zkAssetOwnable.address, transferProofHash, 0, opts);
 
             await zkAssetOwnableTest.callValidateProof(JOIN_SPLIT_PROOF, transferProof.proofData);

--- a/packages/protocol/test/ERC1724/ZkAssetOwnable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetOwnable.js
@@ -23,18 +23,6 @@ const ZkAssetOwnableTest = artifacts.require('./ZkAssetOwnableTest');
 
 JoinSplit.abi = JoinSplitInterface.abi;
 
-const signNote = (validatorAddress, noteHash, spender, privateKey) => {
-    const domain = signer.generateZKAssetDomainParams(validatorAddress);
-    const schema = constants.eip712.NOTE_SIGNATURE;
-    const status = true;
-    const message = {
-        noteHash,
-        spender,
-        status,
-    };
-    return signer.signTypedData(domain, schema, message, privateKey);
-};
-
 contract('ZkAssetOwnable', (accounts) => {
     let ace;
     let aztecJoinSplit;
@@ -50,7 +38,7 @@ contract('ZkAssetOwnable', (accounts) => {
     const confidentialApprove = async (indexes, notes, aztecAccounts) => {
         await Promise.all(
             indexes.map((i) => {
-                const { signature } = signNote(
+                const { signature } = signer.signNote(
                     zkAssetOwnable.address,
                     notes[i].noteHash,
                     zkAssetOwnableTest.address,
@@ -255,7 +243,7 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 30, { from: accounts[0] });
             await zkAssetOwnable.confidentialTransfer(depositProof.proofData, depositProof.signatures);
 
-            const { signature } = signNote(
+            const { signature } = signer.signNote(
                 zkAssetOwnable.address,
                 notes[0].noteHash,
                 zkAssetOwnableTest.address,
@@ -308,7 +296,7 @@ contract('ZkAssetOwnable', (accounts) => {
             await zkAssetOwnable.confidentialTransfer(depositProof.proofData, depositProof.signatures);
             await zkAssetOwnable.confidentialTransfer(transferProof.proofData, transferProof.signatures);
 
-            const { signature } = signNote(
+            const { signature } = signer.signNote(
                 zkAssetOwnable.address,
                 notes[0].noteHash,
                 zkAssetOwnableTest.address,

--- a/packages/protocol/test/ERC1724/ZkAssetOwnable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetOwnable.js
@@ -23,7 +23,7 @@ const ZkAssetOwnableTest = artifacts.require('./ZkAssetOwnableTest');
 
 JoinSplit.abi = JoinSplitInterface.abi;
 
-contract('ZkAssetOwnable', (accounts) => {
+contract.only('ZkAssetOwnable', (accounts) => {
     let ace;
     let aztecJoinSplit;
     let erc20;
@@ -38,7 +38,7 @@ contract('ZkAssetOwnable', (accounts) => {
     const confidentialApprove = async (indexes, notes, aztecAccounts) => {
         await Promise.all(
             indexes.map((i) => {
-                const { signature } = signer.signNote(
+                const { signature } = signer.signNoteZkAssetDomain(
                     zkAssetOwnable.address,
                     notes[i].noteHash,
                     zkAssetOwnableTest.address,
@@ -243,7 +243,7 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProofHash, 30, { from: accounts[0] });
             await zkAssetOwnable.confidentialTransfer(depositProof.proofData, depositProof.signatures);
 
-            const { signature } = signer.signNote(
+            const { signature } = signer.signNoteZkAssetDomain(
                 zkAssetOwnable.address,
                 notes[0].noteHash,
                 zkAssetOwnableTest.address,
@@ -296,7 +296,7 @@ contract('ZkAssetOwnable', (accounts) => {
             await zkAssetOwnable.confidentialTransfer(depositProof.proofData, depositProof.signatures);
             await zkAssetOwnable.confidentialTransfer(transferProof.proofData, transferProof.signatures);
 
-            const { signature } = signer.signNote(
+            const { signature } = signer.signNoteZkAssetDomain(
                 zkAssetOwnable.address,
                 notes[0].noteHash,
                 zkAssetOwnableTest.address,

--- a/packages/protocol/test/libs/LibEIP712.js
+++ b/packages/protocol/test/libs/LibEIP712.js
@@ -49,7 +49,11 @@ contract('LibEIP712', (accounts) => {
 
         it('should recover the sender address', async () => {
             const aztecAccount = secp256k1.generateAccount();
-            const { signature, encodedTypedData } = signer.signNote(libEIP712.address, aztecAccount.address, aztecAccount.privateKey);
+            const { signature, encodedTypedData } = signer.signNote(
+                libEIP712.address,
+                aztecAccount.address,
+                aztecAccount.privateKey,
+            );
             const concatenatedSignature = signature[0] + signature[1].slice(2) + signature[2].slice(2);
             const result = await libEIP712._recoverSignature(encodedTypedData, concatenatedSignature);
             expect(result).to.equal(aztecAccount.address);
@@ -59,7 +63,11 @@ contract('LibEIP712', (accounts) => {
     describe('Failure States', async () => {
         it('should fail when signer is 0x0', async () => {
             const aztecAccount = secp256k1.generateAccount();
-            const { signature, encodedTypedData } = signer.signNote(libEIP712.address, aztecAccount.address, aztecAccount.privateKey);
+            const { signature, encodedTypedData } = signer.signNote(
+                libEIP712.address,
+                aztecAccount.address,
+                aztecAccount.privateKey,
+            );
 
             // see https://ethereum.stackexchange.com/questions/69328/how-to-get-0x0-from-ecrecover/69329#69329
             const v = padLeft('0x10', 64);

--- a/packages/protocol/test/libs/LibEIP712.js
+++ b/packages/protocol/test/libs/LibEIP712.js
@@ -26,18 +26,6 @@ const computeMsgHash = (domainHash, sender) => {
     return { hashStruct, msgHash };
 };
 
-const signNote = (verifyingContract, spender, privateKey) => {
-    const domain = signer.generateAZTECDomainParams(verifyingContract, constants.eip712.ACE_DOMAIN_PARAMS);
-    const schema = constants.eip712.NOTE_SIGNATURE;
-
-    const message = {
-        noteHash: `0x${crypto.randomBytes(32).toString('hex')}`,
-        spender,
-        status: true,
-    };
-    return signer.signTypedData(domain, schema, message, privateKey);
-};
-
 contract('LibEIP712', (accounts) => {
     let libEIP712;
 
@@ -61,7 +49,7 @@ contract('LibEIP712', (accounts) => {
 
         it('should recover the sender address', async () => {
             const aztecAccount = secp256k1.generateAccount();
-            const { signature, encodedTypedData } = signNote(libEIP712.address, aztecAccount.address, aztecAccount.privateKey);
+            const { signature, encodedTypedData } = signer.signNote(libEIP712.address, aztecAccount.address, aztecAccount.privateKey);
             const concatenatedSignature = signature[0] + signature[1].slice(2) + signature[2].slice(2);
             const result = await libEIP712._recoverSignature(encodedTypedData, concatenatedSignature);
             expect(result).to.equal(aztecAccount.address);
@@ -71,7 +59,7 @@ contract('LibEIP712', (accounts) => {
     describe('Failure States', async () => {
         it('should fail when signer is 0x0', async () => {
             const aztecAccount = secp256k1.generateAccount();
-            const { signature, encodedTypedData } = signNote(libEIP712.address, aztecAccount.address, aztecAccount.privateKey);
+            const { signature, encodedTypedData } = signer.signNote(libEIP712.address, aztecAccount.address, aztecAccount.privateKey);
 
             // see https://ethereum.stackexchange.com/questions/69328/how-to-get-0x0-from-ecrecover/69329#69329
             const v = padLeft('0x10', 64);

--- a/packages/protocol/test/libs/LibEIP712.js
+++ b/packages/protocol/test/libs/LibEIP712.js
@@ -31,7 +31,7 @@ const computeMsgHash = (domainHash, sender) => {
     };
 };
 
-contract.only('LibEIP712', (accounts) => {
+contract('LibEIP712', (accounts) => {
     let libEIP712;
 
     beforeEach(async () => {

--- a/packages/protocol/test/libs/LibEIP712.js
+++ b/packages/protocol/test/libs/LibEIP712.js
@@ -11,8 +11,10 @@ const { keccak256, padLeft } = require('web3-utils');
 const LibEIP712 = artifacts.require('./LibEIP712Test');
 
 const computeDomainHash = (validatorAddress) => {
-    const types = { EIP712Domain: constants.eip712.EIP712_DOMAIN };
-    const domain = signer.generateAZTECDomainParams(validatorAddress, constants.eip712.ACE_DOMAIN_PARAMS);
+    const types = {
+        EIP712Domain: constants.eip712.EIP712_DOMAIN,
+    };
+    const domain = signer.generateACEDomainParams(validatorAddress, constants.eip712.ACE_DOMAIN_PARAMS);
     return keccak256(`0x${typedData.encodeMessageData(types, 'EIP712Domain', domain)}`);
 };
 
@@ -23,10 +25,13 @@ const computeMsgHash = (domainHash, sender) => {
     const hashStruct = keccak256([constants.JOIN_SPLIT_SIGNATURE_TYPE_HASH, noteHash, encodedSender, status].join(''));
     const msg = ['0x1901', domainHash.slice(2), hashStruct.slice(2)].join('');
     const msgHash = keccak256(msg);
-    return { hashStruct, msgHash };
+    return {
+        hashStruct,
+        msgHash,
+    };
 };
 
-contract('LibEIP712', (accounts) => {
+contract.only('LibEIP712', (accounts) => {
     let libEIP712;
 
     beforeEach(async () => {
@@ -49,7 +54,7 @@ contract('LibEIP712', (accounts) => {
 
         it('should recover the sender address', async () => {
             const aztecAccount = secp256k1.generateAccount();
-            const { signature, encodedTypedData } = signer.signNote(
+            const { signature, encodedTypedData } = signer.signNoteACEDomain(
                 libEIP712.address,
                 aztecAccount.address,
                 aztecAccount.privateKey,
@@ -63,7 +68,7 @@ contract('LibEIP712', (accounts) => {
     describe('Failure States', async () => {
         it('should fail when signer is 0x0', async () => {
             const aztecAccount = secp256k1.generateAccount();
-            const { signature, encodedTypedData } = signer.signNote(
+            const { signature, encodedTypedData } = signer.signNoteACEDomain(
                 libEIP712.address,
                 aztecAccount.address,
                 aztecAccount.privateKey,


### PR DESCRIPTION
## Summary
Move the `signNote()` function from tests in `LIBEIP712.js` and `ZkAssetOwnable.js` to the `signer` of `aztec.js`.

Notes can be signed under different domains - i.e. for a `ZkAsset.sol` or `ACE.sol` contract - and so there are now two versions of the `signNote()` function:
1) signNoteACEDomain()
2) signNoteZkAssetDomain()
