### PR TITLE
fix: add dev tag to module docs to stop build fail

### DIFF
--- a/packages/aztec.js/test/initDatabase.js
+++ b/packages/aztec.js/test/initDatabase.js
@@ -1,7 +1,7 @@
 /**
  * @module initDatabase
  *
- * This initialises the local trusted setup database, used for testing purposes.
+ * @dev This initialises the local trusted setup database, used for testing purposes.
  * It contains 14,000 points - representing ~1.4% of the original in house trusted
  * setup.
  */

--- a/packages/protocol/test/initDatabase.js
+++ b/packages/protocol/test/initDatabase.js
@@ -1,7 +1,7 @@
 /**
  * @module initDatabase
  *
- * This initialises the local trusted setup database, used for testing purposes.
+ * @dev This initialises the local trusted setup database, used for testing purposes.
  * It contains 14,000 points - representing ~1.4% of the original in house trusted
  * setup.
  */


### PR DESCRIPTION
## Summary
Add the @dev tag to module comments for initDatabase.js

Docs was failing to build without it

