### PR TITLE
Fix proof ids, POINTS_DB_URL, artifacts

### DIFF
--- a/packages/aztec.js/src/setup/index.js
+++ b/packages/aztec.js/src/setup/index.js
@@ -15,9 +15,10 @@ const fetch = require('cross-fetch');
 const bn128 = require('../bn128');
 
 const compressionMask = new BN('8000000000000000000000000000000000000000000000000000000000000000', 16);
-const POINTS_DB_URL = 'https://ds8m7zxw3jpbz.cloudfront.net/data';
 
-const setup = {};
+const setup = {
+    POINTS_DB_URL: 'https://ds8m7zxw3jpbz.cloudfront.net/data',
+};
 
 /**
  * Decompress a 256-bit representation of a bn128 G1 element.
@@ -80,7 +81,7 @@ setup.fetchPoint = async (inputValue) => {
     const fileNum = Math.ceil(Number(value + 1) / constants.SIGNATURES_PER_FILE);
 
     try {
-        const res = await fetch(`${POINTS_DB_URL}${fileNum * constants.SIGNATURES_PER_FILE - 1}.dat`);
+        const res = await fetch(`${setup.POINTS_DB_URL}${fileNum * constants.SIGNATURES_PER_FILE - 1}.dat`);
         if (res.status === 404) {
             throw new Error('point not found');
         }

--- a/packages/contract-artifacts/src/index.js
+++ b/packages/contract-artifacts/src/index.js
@@ -10,8 +10,11 @@ const DividendComputationABIEncoder = require('../artifacts/DividendComputationA
 const DividendComputationInterface = require('../artifacts/DividendComputationInterface');
 const ERC20Mintable = require('../artifacts/ERC20Mintable');
 const GenericABIEncoder = require('../artifacts/GenericABIEncoder');
+const IACE = require('../artifacts/IACE');
 const IAZTEC = require('../artifacts/IAZTEC');
 const IZkAsset = require('../artifacts/IZkAsset');
+const IZkAssetBurnable = require('../artifacts/IZkAssetBurnable');
+const IZkAssetMintable = require('../artifacts/IZkAssetMintable');
 const JoinSplit = require('../artifacts/JoinSplit');
 const JoinSplitABIEncoder = require('../artifacts/JoinSplitABIEncoder');
 const JoinSplitInterface = require('../artifacts/JoinSplitInterface');
@@ -42,8 +45,11 @@ module.exports = {
     DividendComputationInterface,
     ERC20Mintable,
     GenericABIEncoder,
+    IACE,
     IAZTEC,
     IZkAsset,
+    IZkAssetBurnable,
+    IZkAssetMintable,
     JoinSplit,
     JoinSplitABIEncoder,
     JoinSplitInterface,

--- a/packages/dev-utils/src/proofs.js
+++ b/packages/dev-utils/src/proofs.js
@@ -12,7 +12,5 @@ module.exports = {
     DIVIDEND_PROOF: '66561',
     JOIN_SPLIT_PROOF: '65793',
     MINT_PROOF: '66049',
-    // TODO: remove this duplicate value
-    UTILITY_PROOF: '66561',
     PRIVATE_RANGE_PROOF: '66562',
 };

--- a/packages/monorepo-scripts/addresses/update.js
+++ b/packages/monorepo-scripts/addresses/update.js
@@ -17,6 +17,7 @@ const deployedContracts = [
     'DividendComputation',
     'ERC20Mintable',
     'JoinSplit',
+    'PrivateRange',
     'ZkAsset',
 ];
 

--- a/packages/monorepo-scripts/artifacts/build.js
+++ b/packages/monorepo-scripts/artifacts/build.js
@@ -6,7 +6,7 @@ const CONTRACTS_DIR = path.join(__dirname, '..', '..', 'protocol', 'build', 'con
 const ARTIFACTS_DIR = path.join(__dirname, '..', '..', 'contract-artifacts', 'artifacts');
 const ARTIFACTS_DIR_AUX = path.join(__dirname, '..', '..', 'contract-artifacts', 'artifacts-aux');
 
-const abiSwapContracts = ['AdjustSupply', 'BilateralSwap', 'DividendComputation', 'JoinSplit'];
+const abiSwapContracts = ['AdjustSupply', 'BilateralSwap', 'DividendComputation', 'JoinSplit', 'PrivateRange'];
 const excludedContracts = ['ERC20', 'IERC20', 'Migrations', 'Ownable', 'SafeMath'];
 
 const cherrypickContractJson = async (filename) => {

--- a/packages/protocol/contracts/interfaces/IAZTEC.sol
+++ b/packages/protocol/contracts/interfaces/IAZTEC.sol
@@ -30,6 +30,11 @@ contract IAZTEC {
     // (1 * 256**(2)) + (4 * 256**(1)) + (2 * 256**(0))
     uint24 public constant PRIVATE_RANGE_PROOF = 66562;
 
+    // proofEpoch = 1 | proofCategory = 4 | proofId = 1
+    // (1 * 256**(2)) + (4 * 256**(1)) + (2 * 256**(0))
+    uint24 public constant DIVIDEND_PROOF = 66561;
+
+
     // Hash of a dummy AZTEC note with k = 0 and a = 1
     bytes32 public constant ZERO_VALUE_NOTE_HASH = 0xcbc417524e52b95c42a4c42d357938497e3d199eb9b4a0139c92551d4000bc3c;
 }

--- a/packages/protocol/migrations/8_deploy_private_range.js
+++ b/packages/protocol/migrations/8_deploy_private_range.js
@@ -1,0 +1,15 @@
+/* global artifacts */
+const { proofs } = require('@aztec/dev-utils');
+
+const ACE = artifacts.require('./ACE.sol');
+const PrivateRange = artifacts.require('./PrivateRange.sol');
+const PrivateRangeInterface = artifacts.require('./PrivateRangeInterface.sol');
+
+PrivateRange.abi = PrivateRangeInterface.abi;
+
+module.exports = (deployer) => {
+    return deployer.deploy(PrivateRange).then(async ({ address: privateRangeAddress }) => {
+        const ace = await ACE.at(ACE.address);
+        await ace.setProof(proofs.PRIVATE_RANGE_PROOF, privateRangeAddress);
+    });
+};

--- a/packages/protocol/test/ACE/ACEAdjustSupply.js
+++ b/packages/protocol/test/ACE/ACEAdjustSupply.js
@@ -674,7 +674,7 @@ contract('ACE Mint and Burn Functionality', (accounts) => {
             expect(burnReceipt.status).to.equal(true);
         });
 
-        it.only('should not update the validatedProofs mapping for utility proofs', async () => {
+        it('should not update the validatedProofs mapping for utility proofs', async () => {
             // Using a bilateral swap proof
             console.log('entered the test');
             console.log('dividend proof number', DIVIDEND_PROOF);


### PR DESCRIPTION
## Problems
1) There was a redundant proofID defined in the `dev-utils` package - `UTILITY_PROOF`. It is not used for anything and was a placeholder left over from development. It has the same value as the `DIVIDEND_PROOF` ID, so was causing problems. 
2) The `POINTS_DB_URL` can not at the moment be updated. This is problematic if the URL does not behave as expected
3) The `PrivateRange.sol` was not deployed on testnets and no artifact was created for it

## Fixes
1) Removes the `UTILITY_PROOF` Id and updates the tests. Adds the `DIVIDEND_PROOF` Id into `IAZTEC`
2) Moves the `POINTS_DB_URL` definition into the `setup` module as a key:value pair - so it can be overwritten if need be
3) Write the `PrivateRange.sol` deployment script, and generate artifact
