### PR TITLE
fix(huff): jump table offsets

### DIFF
--- a/packages/huff/src/parser.js
+++ b/packages/huff/src/parser.js
@@ -241,7 +241,7 @@ parser.processMacro = (
             throw new Error(`expected to find ${tableInstance.label} in ${JSON.stringify(tableOffsets)}`);
         }
         const { offset } = tableInstance;
-        const placeholder = bytecode.slice((offset * 2) + 2, (offset * 2) + 6);
+        const placeholder = bytecode.slice(offset * 2 + 2, offset * 2 + 6);
         if (placeholder !== 'xxxx') {
             throw new Error(`expected ${placeholder} to be xxxx at offset ${tableInstance.offset}`);
         }

--- a/packages/huff/src/parser.js
+++ b/packages/huff/src/parser.js
@@ -241,12 +241,13 @@ parser.processMacro = (
             throw new Error(`expected to find ${tableInstance.label} in ${JSON.stringify(tableOffsets)}`);
         }
         const { offset } = tableInstance;
-        if (bytecode.slice(offset * 2 + 2, offset * 2 + 6) !== 'xxxx') {
-            throw new Error(`expected ${tableInstance.offset} to be xxxx`);
+        const placeholder = bytecode.slice((offset * 2) + 2, (offset * 2) + 6);
+        if (placeholder !== 'xxxx') {
+            throw new Error(`expected ${placeholder} to be xxxx at offset ${tableInstance.offset}`);
         }
         const pre = bytecode.slice(0, offset * 2 + 2);
         const post = bytecode.slice(offset * 2 + 6);
-        bytecode = `${pre}${formatEvenBytes(toHex(tableOffsets[tableInstance.label]))}${post}`;
+        bytecode = `${pre}${padNBytes(formatEvenBytes(toHex(tableOffsets[tableInstance.label])), 2)}${post}`;
     });
     return {
         ...result,


### PR DESCRIPTION
Jump table offsets are assumed to be 2 bytes, but this is not enforced in the parser. As a result, smaller offsets are broken because when you read the jump location you also end up pushing some bytecode.

To test this, run the example jump table code
```
#define jumptable JUMP_TABLE {
    lsb_0 lsb_1 lsb_2 lsb_3 lsb_4
}

#define macro EXAMPLE = takes(0) returns(0) {
    0x01
    __tablesize(JUMP_TABLE) __tablestart(JUMP_TABLE) 0x00 codecopy
    0x00 calldataload mload jump
    lsb_0:
        0x00 add stop
    lsb_1:
        0x01 add stop
    lsb_2:
        0x02 add stop
    lsb_3:
        0x03 add stop
    lsb_4:
        0x04 add stop
}
```
with
```
const main = new Runtime('example.huff', 'test');
  for(let i = 0; i < 5; i++) await main('EXAMPLE', [], [], [{ index: 0, value: (i*32).toString(16) }], 0)
    .then(({stack}) => console.log(stack));
```
Old Output
```
[ <BN: 1>, <BN: c0>, <BN: 2860> ]
[ <BN: 1>, <BN: c0>, <BN: 2860> ]
[ <BN: 1>, <BN: c0>, <BN: 2860> ]
[ <BN: 1>, <BN: c0>, <BN: 2860> ]
[ <BN: 1>, <BN: c0>, <BN: 2860> ]
```
New Output
```
[ <BN: 1> ]
[ <BN: 2> ]
[ <BN: 3> ]
[ <BN: 4> ]
[ <BN: 5> ]
```

I also modified the error message for failures to find jump table offset placeholders, as I found the message to be extremely uninformative.