### PR TITLE
Feat public range proof

### DIFF
--- a/packages/aztec.js/src/proof/index.js
+++ b/packages/aztec.js/src/proof/index.js
@@ -6,6 +6,7 @@ const MintProof = require('./joinSplitFluid/mint');
 const { Proof, ProofType } = require('./proof');
 const ProofUtils = require('./utils');
 const PrivateRangeProof = require('./privateRange');
+const PublicRangeProof = require('./publicRange');
 const SwapProof = require('./swap');
 
 module.exports = {
@@ -18,5 +19,6 @@ module.exports = {
     Proof,
     ProofType,
     ProofUtils,
+    PublicRangeProof,
     SwapProof,
 };

--- a/packages/aztec.js/src/proof/publicRange/helpers.js
+++ b/packages/aztec.js/src/proof/publicRange/helpers.js
@@ -39,7 +39,7 @@ helpers.constructUtilityNote = async (originalNote, publicInteger) => {
         }
         const utilityNote = await note.create(aztecAccount.publicKey, utilityValue);
         notes = [originalNote, utilityNote];
-    };
+    }
     return notes;
 };
 

--- a/packages/aztec.js/src/proof/publicRange/helpers.js
+++ b/packages/aztec.js/src/proof/publicRange/helpers.js
@@ -6,7 +6,7 @@ const helpers = {};
  * Check that the publicComparison integer is well formed. Specifically, check that it is positive and
  * that it is an integer.
  * @method checkPublicComparisonWellFormed
- * @param {Number} publicComparison - array of proof data from proof construction
+ * @param {Number} publicComparison - publicly visible integer, against which an AZTEC note is being compared
  */
 helpers.checkPublicComparisonWellFormed = (publicComparison) => {
     if (publicComparison < 0) {
@@ -28,7 +28,7 @@ helpers.checkPublicComparisonWellFormed = (publicComparison) => {
 /**
  * Check whether publicComparison is an integer
  *
- * @method isFloat
+ * @method isInteger
  * @param {Number} number - JavaScript number to be checked whether it is a float or not
  * @returns boolean - true if input is an integer, false if it is a float
  */

--- a/packages/aztec.js/src/proof/publicRange/helpers.js
+++ b/packages/aztec.js/src/proof/publicRange/helpers.js
@@ -1,0 +1,80 @@
+const secp256k1 = require('@aztec/secp256k1');
+const { constants, errors } = require('@aztec/dev-utils');
+const note = require('../../note');
+
+const helpers = {};
+/**
+ * Construct a utility note for the publicRange proof
+ *
+ * @dev Utility note is used to construct a balancing relationship
+ * for the sigma protocol to prove. Balancing relationship is:
+ *
+ * originalNoteValue = publicInteger + utilityNoteValue
+ *
+ * @method constructUtilityNote
+ * @memberof module:publicRange
+ * @param {Note[]} originalNote - note whose value is being compared to publicInteger
+ * @param {Integer} publicInteger - publicInteger which the originalNote is being compared against
+ * @returns {Note[]} array of AZTEC notes; specifically including originalNote,
+ * comparisonNote and utilityNote
+ */
+helpers.constructUtilityNote = async (originalNote, publicInteger) => {
+    let notes = [];
+    let utilityValue;
+
+    const aztecAccount = secp256k1.generateAccount();
+    if (originalNote.k !== undefined && publicInteger !== undefined) {
+        const originalValue = originalNote.k.toNumber();
+
+        if (originalValue > publicInteger) {
+            utilityValue = originalValue - publicInteger;
+        } else if (originalValue === publicInteger) {
+            utilityValue = 0;
+        } else {
+            throw errors.customError(constants.errorTypes.INCORRECT_NOTE_RELATION, {
+                message: 'notes supplied with publicInteger being less than originalValue',
+                originalValue,
+                publicInteger,
+            });
+        }
+        const utilityNote = await note.create(aztecAccount.publicKey, utilityValue);
+        notes = [originalNote, utilityNote];
+    };
+    return notes;
+};
+
+/**
+ * Check that the publicInteger integer is well formed. Specifically, check that it is positive and
+ * that it is an integer.
+ * @method checkpublicIntegerWellFormed
+ * @param {string[]} publicInteger - array of proof data from proof construction
+ */
+helpers.checkpublicIntegerWellFormed = (publicInteger) => {
+    if (publicInteger < 0) {
+        throw errors.customError(constants.errorTypes.PUBLIC_COMPARISON_NEGATIVE, {
+            message: 'publicInteger is negative, has to be positive',
+            publicInteger,
+        });
+    }
+
+    if (!helpers.isInteger(publicInteger)) {
+        throw errors.customError(constants.errorTypes.NOT_INTEGER, {
+            message: 'publicInteger is not an integer, it has to be',
+            publicInteger,
+            type: typeof publicInteger,
+        });
+    }
+};
+
+/**
+ * Check whether publicInteger is an integer
+ *
+ * @method isFloat
+ * @param number - JavaScript number to be checked whether it is a float or not
+ * @returns boolean - true if input is an integer, false if it is a float
+ */
+helpers.isInteger = (number) => {
+    return number % 1 === 0;
+};
+
+module.exports = helpers;

--- a/packages/aztec.js/src/proof/publicRange/helpers.js
+++ b/packages/aztec.js/src/proof/publicRange/helpers.js
@@ -1,76 +1,35 @@
-const secp256k1 = require('@aztec/secp256k1');
 const { constants, errors } = require('@aztec/dev-utils');
-const note = require('../../note');
 
 const helpers = {};
-/**
- * Construct a utility note for the publicRange proof
- *
- * @dev Utility note is used to construct a balancing relationship
- * for the sigma protocol to prove. Balancing relationship is:
- *
- * originalNoteValue = publicInteger + utilityNoteValue
- *
- * @method constructUtilityNote
- * @memberof module:publicRange
- * @param {Note[]} originalNote - note whose value is being compared to publicInteger
- * @param {Integer} publicInteger - publicInteger which the originalNote is being compared against
- * @returns {Note[]} array of AZTEC notes; specifically including originalNote,
- * comparisonNote and utilityNote
- */
-helpers.constructUtilityNote = async (originalNote, publicInteger) => {
-    let notes = [];
-    let utilityValue;
-
-    const aztecAccount = secp256k1.generateAccount();
-    if (originalNote.k !== undefined && publicInteger !== undefined) {
-        const originalValue = originalNote.k.toNumber();
-
-        if (originalValue > publicInteger) {
-            utilityValue = originalValue - publicInteger;
-        } else if (originalValue === publicInteger) {
-            utilityValue = 0;
-        } else {
-            throw errors.customError(constants.errorTypes.INCORRECT_NOTE_RELATION, {
-                message: 'notes supplied with publicInteger being less than originalValue',
-                originalValue,
-                publicInteger,
-            });
-        }
-        const utilityNote = await note.create(aztecAccount.publicKey, utilityValue);
-        notes = [originalNote, utilityNote];
-    }
-    return notes;
-};
 
 /**
- * Check that the publicInteger integer is well formed. Specifically, check that it is positive and
+ * Check that the publicComparison integer is well formed. Specifically, check that it is positive and
  * that it is an integer.
- * @method checkpublicIntegerWellFormed
- * @param {string[]} publicInteger - array of proof data from proof construction
+ * @method checkPublicComparisonWellFormed
+ * @param {Number} publicComparison - array of proof data from proof construction
  */
-helpers.checkpublicIntegerWellFormed = (publicInteger) => {
-    if (publicInteger < 0) {
+helpers.checkPublicComparisonWellFormed = (publicComparison) => {
+    if (publicComparison < 0) {
         throw errors.customError(constants.errorTypes.PUBLIC_COMPARISON_NEGATIVE, {
-            message: 'publicInteger is negative, has to be positive',
-            publicInteger,
+            message: 'publicComparison is negative, has to be positive',
+            publicComparison,
         });
     }
 
-    if (!helpers.isInteger(publicInteger)) {
+    if (!helpers.isInteger(publicComparison)) {
         throw errors.customError(constants.errorTypes.NOT_INTEGER, {
-            message: 'publicInteger is not an integer, it has to be',
-            publicInteger,
-            type: typeof publicInteger,
+            message: 'publicComparison is not an integer, it has to be',
+            publicComparison,
+            type: typeof publicComparison,
         });
     }
 };
 
 /**
- * Check whether publicInteger is an integer
+ * Check whether publicComparison is an integer
  *
  * @method isFloat
- * @param number - JavaScript number to be checked whether it is a float or not
+ * @param {Number} number - JavaScript number to be checked whether it is a float or not
  * @returns boolean - true if input is an integer, false if it is a float
  */
 helpers.isInteger = (number) => {

--- a/packages/aztec.js/src/proof/publicRange/index.js
+++ b/packages/aztec.js/src/proof/publicRange/index.js
@@ -14,7 +14,7 @@ const { AztecError } = errors;
 class PublicRangeProof extends Proof {
     /**
      * Constructs a public range proof that a note is greater than or equal to, or less than or
-     * equal to a public integer. Control of whether a > or < proof is constructed is controlled
+     * equal to a public integer. Control of whether a > or < proof is constructed is determined
      * by an input boolean 'isGreaterOrEqual'
      *
      * @param {Object} originalNote the note that a user is comparing against the publicInteger
@@ -23,16 +23,15 @@ class PublicRangeProof extends Proof {
      * @param {bool} isGreaterOrEqual modifier controlling whether this is a greater than, or less
      * than proof. If true, it is a proof that originalNoteValue > publicInteger. If false, it is a
      * proof that originalNoteValue < publicInteger
-     * @param {Note} utilityNote
+     * @param {Note} utilityNote a helper note that is needed to satisfy a cryptographic balancing relation
+     * (to be abstracted away)
      */
     constructor(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote) {
         const publicValue = constants.ZERO_BN;
         const publicOwner = constants.addresses.ZERO_ADDRESS;
+        super(ProofType.PUBLIC_RANGE.name, [originalNote], [utilityNote], sender, publicValue, publicOwner, [utilityNote]);
 
-        super(ProofType.PUBLIC_RANGE.name, [originalNote], [utilityNote], sender, publicValue, publicOwner, [
-            utilityNote,
-        ]);
-
+        helpers.checkpublicIntegerWellFormed(publicInteger);
         this.publicInteger = new BN(publicInteger);
         this.utilityNote = utilityNote;
         this.originalNote = originalNote;

--- a/packages/aztec.js/src/proof/publicRange/index.js
+++ b/packages/aztec.js/src/proof/publicRange/index.js
@@ -21,7 +21,7 @@ class PublicRangeProof extends Proof {
      * originalNoteValue = publicComparison + utilityNoteValue
      *
      * @param {Object} originalNote the note that a user is comparing against the publicComparison
-     * @param {Object} publicComparison publicly visible integer, which the note is being compared against
+     * @param {Number} publicComparison publicly visible integer, which the note is being compared against
      * @param {string} sender Ethereum address of the transaction sender
      * @param {bool} isGreaterOrEqual modifier controlling whether this is a greater than, or less
      * than proof. If true, it is a proof that originalNoteValue > publicComparison. If false, it is a

--- a/packages/aztec.js/src/proof/publicRange/index.js
+++ b/packages/aztec.js/src/proof/publicRange/index.js
@@ -1,0 +1,151 @@
+const bn128 = require('@aztec/bn128');
+const { constants, errors, proofs } = require('@aztec/dev-utils');
+const BN = require('bn.js');
+const { AbiCoder } = require('web3-eth-abi');
+const { keccak256, padLeft } = require('web3-utils');
+
+const { inputCoder, outputCoder } = require('../../encoder');
+const { Proof, ProofType } = require('../proof');
+const ProofUtils = require('../utils');
+
+const { AztecError } = errors;
+
+class PublicRangeProof extends Proof {
+    /**
+     * Constructs a public range proof
+     *
+     * @param {Object} originalNote the note that one is computing a dividend of
+     * @param {Object} publicComparison the note that represents the integer rounding error
+     * @param {string} sender
+     */
+    constructor(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote) {
+        const publicValue = constants.ZERO_BN;
+        const publicOwner = constants.addresses.ZERO_ADDRESS;
+        super(ProofType.PUBLIC_RANGE.name, [originalNote], [utilityNote], sender, publicValue, publicOwner, [utilityNote]);
+        this.publicInteger = new BN(publicInteger);
+
+        this.constructBlindingFactors();
+        this.constructChallenge();
+        this.constructData();
+        this.constructOutputs();
+    }
+
+    constructBlindingFactors() {
+        const blindingScalars = Array(this.notes.length)
+            .fill()
+            .map(() => {
+                return {
+                    bk: bn128.randomGroupScalar(),
+                    ba: bn128.randomGroupScalar(),
+                };
+            });
+
+        let B;
+        this.blindingFactors = this.notes.map((note, i) => {
+            const { bk } = blindingScalars[0]; // trivially true for i=0, and enforcing k1 = k2 for i=1
+            const { ba } = blindingScalars[i];
+
+            if (i === 0) {
+                B = note.gamma.mul(bk).add(bn128.h.mul(ba));
+            }
+
+            if (i === 1) {
+                const reducer = this.rollingHash.redKeccak();
+                const xbk = bk.redMul(reducer);
+                const xba = ba.redMul(reducer);
+                B = note.gamma.mul(xbk).add(bn128.h.mul(xba));
+            }
+            return { bk, ba, B };
+        });
+    }
+
+    constructChallenge() {
+        this.constructChallengeRecurse([
+            this.sender,
+            this.publicInteger,
+            this.publicValue,
+            this.publicOwner,
+            this.notes,
+            this.blindingFactors,
+        ]);
+        this.challenge = this.challengeHash.redKeccak();
+    }
+
+    constructData() {
+        this.data = this.blindingFactors.map(({ bk, ba }, i) => {
+            const note = this.notes[i];
+            const kBar = note.k
+                .redMul(this.challenge)
+                .redAdd(bk)
+                .fromRed();
+            const aBar = note.a
+                .redMul(this.challenge)
+                .redAdd(ba)
+                .fromRed();
+
+            const items = [
+                kBar,
+                aBar,
+                note.gamma.x.fromRed(),
+                note.gamma.y.fromRed(),
+                note.sigma.x.fromRed(),
+                note.sigma.y.fromRed(),
+            ];
+            return items.map((item) => `0x${padLeft(item.toString(16), 64)}`);
+        });
+    }
+
+    // TODO: normalise proof output encoding. In some places it's expected to use `encodeProofOutputs`
+    // while in others `encodeProofOutput`.
+    constructOutputs() {
+        const proofOutput = {
+            inputNotes: this.inputNotes,
+            outputNotes: this.outputNotes,
+            publicValue: this.publicValue,
+            publicOwner: this.publicOwner,
+            challenge: this.challengeHex,
+        };
+        this.output = outputCoder.encodeProofOutput(proofOutput);
+        this.outputs = outputCoder.encodeProofOutputs([proofOutput]);
+        this.hash = outputCoder.hashProofOutput(this.output);
+        this.validatedProofHash = keccak256(
+            new AbiCoder().encodeParameters(
+                ['bytes32', 'uint24', 'address'],
+                [this.hash, proofs.PUBLIC_RANGE_PROOF, this.sender],
+            ),
+        );
+    }
+
+    encodeABI() {
+        // this still needs doing
+        const encodedParams = [
+            inputCoder.encodeProofData(this.data),
+            inputCoder.encodeOwners(this.inputNoteOwners),
+            inputCoder.encodeOwners(this.outputNoteOwners),
+            inputCoder.encodeMetadata(this.metadata),
+        ];
+
+        const length = 2 + encodedParams.length + 1; // what is the +3, +1 for?
+        const offsets = ProofUtils.getOffsets(length, encodedParams);
+        const abiEncodedParams = [
+            this.challengeHex.slice(2),
+            padLeft(Number(this.publicInteger).toString(16), 64),
+            ...offsets,
+            ...encodedParams,
+        ];
+        // console.log('abiEncodedParams: ', abiEncodedParams);
+        return `0x${abiEncodedParams.join('').toLowerCase()}`;
+    }
+
+    validateInputs() {
+        super.validateInputs();
+        if (this.notes.length !== 2) {
+            throw new AztecError(errors.codes.INCORRECT_NOTE_NUMBER, {
+                message: `Public range proofs must contain 2 notes`,
+                numNotes: this.notes.length,
+            });
+        }
+    }
+}
+
+module.exports = PublicRangeProof;

--- a/packages/aztec.js/src/proof/publicRange/verifier.js
+++ b/packages/aztec.js/src/proof/publicRange/verifier.js
@@ -21,7 +21,6 @@ class PublicRangeVerifier extends Verifier {
         challengeResponse.appendBN(new BN(this.proof.publicValue));
         challengeResponse.appendBN(new BN(this.proof.publicOwner.slice(2), 16));
 
-
         const rollingHash = new Keccak();
         this.data.forEach((item) => {
             rollingHash.appendPoint(item.gamma);
@@ -42,7 +41,7 @@ class PublicRangeVerifier extends Verifier {
                     .mul(kBar)
                     .add(bn128.h.mul(aBar))
                     .add(sigma.mul(this.challenge).neg());
-            };
+            }
 
             if (i === 1) {
                 const reducer = rollingHash.redKeccak();
@@ -83,7 +82,12 @@ class PublicRangeVerifier extends Verifier {
             }
         });
 
-        if (!challengeResponse.redKeccak().fromRed().eq(this.challenge.fromRed())) {
+        if (
+            !challengeResponse
+                .redKeccak()
+                .fromRed()
+                .eq(this.challenge.fromRed())
+        ) {
             this.errors.push(errors.codes.CHALLENGE_RESPONSE_FAIL);
         }
     }

--- a/packages/aztec.js/src/proof/publicRange/verifier.js
+++ b/packages/aztec.js/src/proof/publicRange/verifier.js
@@ -1,0 +1,92 @@
+/* eslint-disable prefer-destructuring */
+const bn128 = require('@aztec/bn128');
+const { constants, errors } = require('@aztec/dev-utils');
+const BN = require('bn.js');
+
+const Keccak = require('../../keccak');
+const Verifier = require('../verifier');
+
+const { ZERO_BN } = constants;
+
+class PublicRangeVerifier extends Verifier {
+    verifyProof() {
+        const dataLength = this.proof.data.length;
+        if (dataLength < 2) {
+            this.errors.push(errors.codes.INCORRECT_NOTE_NUMBER);
+        }
+
+        const challengeResponse = new Keccak();
+        challengeResponse.appendBN(this.proof.sender.slice(2));
+        challengeResponse.appendBN(new BN(this.proof.publicInteger));
+        challengeResponse.appendBN(new BN(this.proof.publicValue));
+        challengeResponse.appendBN(new BN(this.proof.publicOwner.slice(2), 16));
+
+
+        const rollingHash = new Keccak();
+        this.data.forEach((item) => {
+            rollingHash.appendPoint(item.gamma);
+            rollingHash.appendPoint(item.sigma);
+        });
+
+        challengeResponse.data = [...challengeResponse.data, ...rollingHash.data];
+
+        let B;
+        this.data.forEach((note, i) => {
+            let kBar;
+            const { aBar, gamma, sigma } = note;
+
+            if (i === 0) {
+                kBar = note.kBar;
+
+                B = gamma
+                    .mul(kBar)
+                    .add(bn128.h.mul(aBar))
+                    .add(sigma.mul(this.challenge).neg());
+            };
+
+            if (i === 1) {
+                const reducer = rollingHash.redKeccak();
+                let kBarX;
+                const firstTerm = this.data[0].kBar;
+                const secondTerm = this.challenge.mul(this.proof.publicInteger);
+                kBar = firstTerm.sub(secondTerm);
+
+                // multiplication in reduction context only works for positive numbers
+                // So, have to check if kBar is negative and if it is, negate it (to make positive),
+                // perform the operation and then negate back
+
+                if (kBar < 0) {
+                    kBar = kBar.neg();
+                    kBarX = kBar.redMul(reducer).neg();
+                } else {
+                    kBarX = kBar.redMul(reducer);
+                }
+
+                const challengeX = this.challenge.redMul(reducer);
+                const aBarX = aBar.redMul(reducer);
+
+                B = gamma
+                    .mul(kBarX)
+                    .add(bn128.h.mul(aBarX))
+                    .add(sigma.mul(challengeX).neg());
+            }
+
+            if (B.isInfinity()) {
+                challengeResponse.appendBN(ZERO_BN);
+                challengeResponse.appendBN(ZERO_BN);
+                this.errors.push(errors.codes.BAD_BLINDING_FACTOR);
+            } else {
+                challengeResponse.appendPoint(B);
+                if (B.x.fromRed().eq(bn128.zeroBnRed) && B.y.fromRed().eq(bn128.zeroBnRed)) {
+                    this.errors.push(errors.codes.BAD_BLINDING_FACTOR);
+                }
+            }
+        });
+
+        if (!challengeResponse.redKeccak().fromRed().eq(this.challenge.fromRed())) {
+            this.errors.push(errors.codes.CHALLENGE_RESPONSE_FAIL);
+        }
+    }
+}
+
+module.exports = PublicRangeVerifier;

--- a/packages/aztec.js/src/proof/publicRange/verifier.js
+++ b/packages/aztec.js/src/proof/publicRange/verifier.js
@@ -17,7 +17,7 @@ class PublicRangeVerifier extends Verifier {
 
         const challengeResponse = new Keccak();
         challengeResponse.appendBN(this.proof.sender.slice(2));
-        challengeResponse.appendBN(new BN(this.proof.publicInteger));
+        challengeResponse.appendBN(new BN(this.proof.publicComparison));
         challengeResponse.appendBN(new BN(this.proof.publicValue));
         challengeResponse.appendBN(new BN(this.proof.publicOwner.slice(2), 16));
 
@@ -47,7 +47,7 @@ class PublicRangeVerifier extends Verifier {
                 const reducer = rollingHash.redKeccak();
                 let kBarX;
                 const firstTerm = this.data[0].kBar;
-                const secondTerm = this.challenge.mul(this.proof.publicInteger);
+                const secondTerm = this.challenge.mul(this.proof.publicComparison);
                 kBar = firstTerm.sub(secondTerm);
 
                 // multiplication in reduction context only works for positive numbers

--- a/packages/aztec.js/src/proof/types.js
+++ b/packages/aztec.js/src/proof/types.js
@@ -1,1 +1,1 @@
-module.exports = ['BURN', 'DIVIDEND', 'JOIN_SPLIT', 'MINT', 'PRIVATE_RANGE', 'SWAP'];
+module.exports = ['BURN', 'DIVIDEND', 'JOIN_SPLIT', 'MINT', 'PRIVATE_RANGE', 'PUBLIC_RANGE', 'SWAP'];

--- a/packages/aztec.js/test/proof/privateRange/verifier.js
+++ b/packages/aztec.js/test/proof/privateRange/verifier.js
@@ -59,13 +59,13 @@ describe('Private range proof Verifier', () => {
         it('should throw error if unsatisfied proof relations', async () => {
             const bogusComparisonValue = 5;
             const bogusComparisonNote = await note.create(publicKey, bogusComparisonValue);
-            let error;
-            try {
-                const _ = new PrivateRangeProof(originalNote, bogusComparisonNote, utilityNote, sender);
-            } catch (err) {
-                error = err;
-            }
-            expect(error.message).to.equal(errors.codes.BALANCING_RELATION_NOT_SATISFIED);
+            const proof = new PrivateRangeProof(originalNote, bogusComparisonNote, utilityNote, sender, false);
+
+            const verifier = new PrivateRangeVerifier(proof);
+            verifier.verifyProof();
+            expect(verifier.isValid).to.equal(false);
+            expect(verifier.errors.length).to.equal(1);
+            expect(verifier.errors[0]).to.equal(errors.codes.CHALLENGE_RESPONSE_FAIL);
         });
 
         it('should fail if malformed challenge', async () => {

--- a/packages/aztec.js/test/proof/publicRange/index.js
+++ b/packages/aztec.js/test/proof/publicRange/index.js
@@ -1,3 +1,4 @@
+const { errors } = require('@aztec/dev-utils');
 const secp256k1 = require('@aztec/secp256k1');
 const { expect } = require('chai');
 const { randomHex } = require('web3-utils');
@@ -6,26 +7,42 @@ const note = require('../../../src/note');
 const { PublicRangeProof } = require('../../../src/proof');
 
 describe('Public range proof', () => {
-    let originalNote = {};
-    const originalNoteValue = 50;
-    let utilityNote = {};
-    const utilityNoteValue = 40;
     const { publicKey } = secp256k1.generateAccount();
+    let originalNote;
+    const originalNoteValue = 50;
+    let utilityNote;
+    const utilityNoteValue = 40;
     const sender = randomHex(20);
     const publicComparison = 10;
-
     const isGreaterOrEqual = true;
 
-    before(async () => {
+    beforeEach(async () => {
         originalNote = await note.create(publicKey, originalNoteValue);
         utilityNote = await note.create(publicKey, utilityNoteValue);
     });
 
-    it('should construct a public range proof with well-formed outputs', async () => {
-        const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
-        expect(proof.data.length).to.equal(2);
-        expect(proof.challengeHex.length).to.equal(66);
-        expect(proof.data[0].length).to.equal(6);
-        expect(proof.data[1].length).to.equal(6);
+    describe('Success states', () => {
+        it('should construct a public range proof with well-formed outputs', async () => {
+            const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
+            expect(proof.data.length).to.equal(2);
+            expect(proof.challengeHex.length).to.equal(66);
+            expect(proof.data[0].length).to.equal(6);
+            expect(proof.data[1].length).to.equal(6);
+        });
+    });
+
+    describe('Failure states', () => {
+        it('should fail if supplied notes do not satisfy balancing relationship', async () => {
+            const bogusUtilityNoteValue = 5;
+            const bogusUtilityNote = await note.create(publicKey, bogusUtilityNoteValue);
+            let error;
+
+            try {
+                const _ = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, bogusUtilityNote);
+            } catch (err) {
+                error = err;
+            }
+            expect(error.message).to.equal(errors.codes.BALANCING_RELATION_NOT_SATISFIED);
+        });
     });
 });

--- a/packages/aztec.js/test/proof/publicRange/index.js
+++ b/packages/aztec.js/test/proof/publicRange/index.js
@@ -1,0 +1,31 @@
+const secp256k1 = require('@aztec/secp256k1');
+const { expect } = require('chai');
+const { randomHex } = require('web3-utils');
+
+const note = require('../../../src/note');
+const { PublicRangeProof } = require('../../../src/proof');
+
+describe('Public range proof', () => {
+    let originalNote = {};
+    const originalNoteValue = 50;
+    let utilityNote = {};
+    const utilityNoteValue = 40;
+    const { publicKey } = secp256k1.generateAccount();
+    const sender = randomHex(20);
+    const publicInteger = 10;
+
+    const isGreaterOrEqual = true;
+
+    before(async () => {
+        originalNote = await note.create(publicKey, originalNoteValue);
+        utilityNote = await note.create(publicKey, utilityNoteValue);
+    });
+
+    it('should construct a public range proof with well-formed outputs', async () => {
+        const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+        expect(proof.data.length).to.equal(2);
+        expect(proof.challengeHex.length).to.equal(66);
+        expect(proof.data[0].length).to.equal(6);
+        expect(proof.data[1].length).to.equal(6);
+    });
+});

--- a/packages/aztec.js/test/proof/publicRange/index.js
+++ b/packages/aztec.js/test/proof/publicRange/index.js
@@ -12,7 +12,7 @@ describe('Public range proof', () => {
     const utilityNoteValue = 40;
     const { publicKey } = secp256k1.generateAccount();
     const sender = randomHex(20);
-    const publicInteger = 10;
+    const publicComparison = 10;
 
     const isGreaterOrEqual = true;
 
@@ -22,7 +22,7 @@ describe('Public range proof', () => {
     });
 
     it('should construct a public range proof with well-formed outputs', async () => {
-        const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+        const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
         expect(proof.data.length).to.equal(2);
         expect(proof.challengeHex.length).to.equal(66);
         expect(proof.data[0].length).to.equal(6);

--- a/packages/aztec.js/test/proof/publicRange/verifier.js
+++ b/packages/aztec.js/test/proof/publicRange/verifier.js
@@ -49,7 +49,7 @@ describe('Public range proof verifier', () => {
         it('should fail for unsatisfied proof relations', async () => {
             const bogusTargetNoteValue = 41;
             const bogusUtilityNote = await note.create(publicKey, bogusTargetNoteValue);
-            const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, bogusUtilityNote);
+            const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, bogusUtilityNote, false);
 
             const verifier = new PublicRangeVerifier(proof);
             verifier.verifyProof();
@@ -59,9 +59,7 @@ describe('Public range proof verifier', () => {
         });
 
         it('should fail for fake challenge', async () => {
-            const bogusTargetNoteValue = 41;
-            const bogusUtilityNote = await note.create(publicKey, bogusTargetNoteValue);
-            const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, bogusUtilityNote);
+            const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
             proof.challenge = new BN(randomHex(31), 16);
 
             const verifier = new PublicRangeVerifier(proof);
@@ -72,9 +70,7 @@ describe('Public range proof verifier', () => {
         });
 
         it('should fail for fake proof data', async () => {
-            const bogusTargetNoteValue = 41;
-            const bogusUtilityNote = await note.create(publicKey, bogusTargetNoteValue);
-            const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, bogusUtilityNote);
+            const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
             proof.data = [];
             for (let i = 0; i < 3; i += 1) {
                 proof.data[i] = [];

--- a/packages/aztec.js/test/proof/publicRange/verifier.js
+++ b/packages/aztec.js/test/proof/publicRange/verifier.js
@@ -12,7 +12,7 @@ const { PublicRangeProof } = require('../../../src/proof');
 const PublicRangeVerifier = require('../../../src/proof/publicRange/verifier');
 const { Proof } = require('../../../src/proof');
 
-describe.only('Public range proof verifier', () => {
+describe('Public range proof verifier', () => {
     let originalNote = {};
     const originalNoteValue = 50;
     let utilityNote = {};

--- a/packages/aztec.js/test/proof/publicRange/verifier.js
+++ b/packages/aztec.js/test/proof/publicRange/verifier.js
@@ -18,7 +18,7 @@ describe('Public range proof verifier', () => {
     const utilityNoteValue = 40;
     const { publicKey } = secp256k1.generateAccount();
     const sender = randomHex(20);
-    const publicInteger = 10;
+    const publicComparison = 10;
 
     const isGreaterOrEqual = true;
 
@@ -28,7 +28,7 @@ describe('Public range proof verifier', () => {
     });
     describe('Success States', () => {
         it('should verify a valid Swap proof', async () => {
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
             const verifier = new PublicRangeVerifier(proof);
             verifier.verifyProof();
             expect(verifier.isValid).to.equal(true);
@@ -49,7 +49,7 @@ describe('Public range proof verifier', () => {
         it('should fail for unsatisfied proof relations', async () => {
             const bogusTargetNoteValue = 41;
             const bogusUtilityNote = await note.create(publicKey, bogusTargetNoteValue);
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, bogusUtilityNote);
+            const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, bogusUtilityNote);
 
             const verifier = new PublicRangeVerifier(proof);
             verifier.verifyProof();
@@ -61,7 +61,7 @@ describe('Public range proof verifier', () => {
         it('should fail for fake challenge', async () => {
             const bogusTargetNoteValue = 41;
             const bogusUtilityNote = await note.create(publicKey, bogusTargetNoteValue);
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, bogusUtilityNote);
+            const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, bogusUtilityNote);
             proof.challenge = new BN(randomHex(31), 16);
 
             const verifier = new PublicRangeVerifier(proof);
@@ -74,7 +74,7 @@ describe('Public range proof verifier', () => {
         it('should fail for fake proof data', async () => {
             const bogusTargetNoteValue = 41;
             const bogusUtilityNote = await note.create(publicKey, bogusTargetNoteValue);
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, bogusUtilityNote);
+            const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, bogusUtilityNote);
             proof.data = [];
             for (let i = 0; i < 3; i += 1) {
                 proof.data[i] = [];
@@ -89,7 +89,7 @@ describe('Public range proof verifier', () => {
         });
 
         it('should fail if points NOT on curve', async () => {
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
             proof.data[0][2] = padLeft('0x00', 64);
 
             const verifier = new PublicRangeVerifier(proof);
@@ -101,7 +101,7 @@ describe('Public range proof verifier', () => {
         });
 
         it('should fail if blinding factor at infinity', async () => {
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
             proof.data[0][0] = padLeft('0x05', 64);
             proof.data[0][1] = padLeft('0x05', 64);
             proof.data[0][2] = `0x${bn128.H_X.toString(16)}`;
@@ -119,7 +119,7 @@ describe('Public range proof verifier', () => {
         });
 
         it('should fail if blinding factor computed from invalid point', async () => {
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
             proof.data[0][0] = `0x${padLeft('', 64)}`;
             proof.data[0][1] = `0x${padLeft('', 64)}`;
             proof.data[0][2] = `0x${padLeft('', 64)}`;

--- a/packages/aztec.js/test/proof/publicRange/verifier.js
+++ b/packages/aztec.js/test/proof/publicRange/verifier.js
@@ -1,0 +1,143 @@
+const bn128 = require('@aztec/bn128');
+const { errors } = require('@aztec/dev-utils');
+const secp256k1 = require('@aztec/secp256k1');
+const BN = require('bn.js');
+const { expect } = require('chai');
+const sinon = require('sinon');
+const { padLeft, randomHex } = require('web3-utils');
+
+
+const note = require('../../../src/note');
+const { PublicRangeProof } = require('../../../src/proof');
+const PublicRangeVerifier = require('../../../src/proof/publicRange/verifier');
+const { Proof } = require('../../../src/proof');
+
+describe.only('Public range proof verifier', () => {
+    let originalNote = {};
+    const originalNoteValue = 50;
+    let utilityNote = {};
+    const utilityNoteValue = 40;
+    const { publicKey } = secp256k1.generateAccount();
+    const sender = randomHex(20);
+    const publicInteger = 10;
+
+    const isGreaterOrEqual = true;
+
+    before(async () => {
+        originalNote = await note.create(publicKey, originalNoteValue);
+        utilityNote = await note.create(publicKey, utilityNoteValue);
+    })
+    describe('Success States', () => {
+        it('should verify a valid Swap proof', async () => {
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            const verifier = new PublicRangeVerifier(proof);
+            verifier.verifyProof();
+            expect(verifier.isValid).to.equal(true);
+            expect(verifier.errors.length).to.equal(0);
+        });
+    });
+
+    describe('Failure states', () => {
+        let validateInputsStub;
+        before(() => {
+            validateInputsStub = sinon.stub(Proof.prototype, 'validateInputs').callsFake(() => {});
+        });
+
+        after(() => {
+            validateInputsStub.restore();
+        });
+
+        it('should fail for unsatisfied proof relations', async () => {
+            const bogusTargetNoteValue = 41;
+            const bogusUtilityNote = await note.create(publicKey, bogusTargetNoteValue);
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, bogusUtilityNote);
+
+            const verifier = new PublicRangeVerifier(proof);
+            verifier.verifyProof();
+            expect(verifier.isValid).to.equal(false);
+            expect(verifier.errors.length).to.equal(1);
+            expect(verifier.errors[0]).to.equal(errors.codes.CHALLENGE_RESPONSE_FAIL);
+        });
+
+        it('should fail for fake challenge', async () => {
+            const bogusTargetNoteValue = 41;
+            const bogusUtilityNote = await note.create(publicKey, bogusTargetNoteValue);
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, bogusUtilityNote);
+            proof.challenge = new BN(randomHex(31), 16);
+
+            const verifier = new PublicRangeVerifier(proof);
+            verifier.verifyProof();
+            expect(verifier.isValid).to.equal(false);
+            expect(verifier.errors.length).to.equal(1);
+            expect(verifier.errors[0]).to.equal(errors.codes.CHALLENGE_RESPONSE_FAIL);
+        });
+
+        it('should fail for fake proof data', async () => {
+            const bogusTargetNoteValue = 41;
+            const bogusUtilityNote = await note.create(publicKey, bogusTargetNoteValue);
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, bogusUtilityNote);
+            proof.data = [];
+            for (let i = 0; i < 3; i += 1) {
+                proof.data[i] = [];
+                for (let j = 0; j < 6; j += 1) {
+                    proof.data[i][j] = randomHex(32);
+                }
+            }
+            const verifier = new PublicRangeVerifier(proof);
+            verifier.verifyProof();
+            expect(verifier.isValid).to.equal(false);
+            expect(verifier.errors[verifier.errors.length - 1]).to.contain(errors.codes.CHALLENGE_RESPONSE_FAIL);
+        });
+
+        it('should fail if points NOT on curve', async () => {
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            proof.data[0][2] = padLeft('0x00', 64);
+
+            const verifier = new PublicRangeVerifier(proof);
+            verifier.verifyProof();
+            expect(verifier.isValid).to.equal(false);
+            expect(verifier.errors.length).to.equal(2);
+            expect(verifier.errors[0]).to.equal(errors.codes.NOT_ON_CURVE);
+            expect(verifier.errors[1]).to.equal(errors.codes.CHALLENGE_RESPONSE_FAIL);
+        });
+
+        it('should fail if blinding factor at infinity', async () => {
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            proof.data[0][0] = padLeft('0x05', 64);
+            proof.data[0][1] = padLeft('0x05', 64);
+            proof.data[0][2] = `0x${bn128.H_X.toString(16)}`;
+            proof.data[0][3] = `0x${bn128.H_Y.toString(16)}`;
+            proof.data[0][4] = `0x${bn128.H_X.toString(16)}`;
+            proof.data[0][5] = `0x${bn128.H_Y.toString(16)}`;
+            proof.challenge = new BN(10).toRed(bn128.groupReduction);
+
+            const verifier = new PublicRangeVerifier(proof);
+            verifier.verifyProof();
+            expect(verifier.isValid).to.equal(false);
+            expect(verifier.errors.length).to.equal(2);
+            expect(verifier.errors[0]).to.equal(errors.codes.BAD_BLINDING_FACTOR);
+            expect(verifier.errors[1]).to.equal(errors.codes.CHALLENGE_RESPONSE_FAIL);
+        });
+
+        it('should fail if blinding factor computed from invalid point', async () => {
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            proof.data[0][0] = `0x${padLeft('', 64)}`;
+            proof.data[0][1] = `0x${padLeft('', 64)}`;
+            proof.data[0][2] = `0x${padLeft('', 64)}`;
+            proof.data[0][3] = `0x${padLeft('', 64)}`;
+            proof.data[0][4] = `0x${padLeft('', 64)}`;
+            proof.data[0][5] = `0x${padLeft('', 64)}`;
+
+            const verifier = new PublicRangeVerifier(proof);
+            verifier.verifyProof();
+            expect(verifier.isValid).to.equal(false);
+            expect(verifier.errors.length).to.equal(6);
+            expect(verifier.errors[0]).to.equal(errors.codes.SCALAR_IS_ZERO);
+            expect(verifier.errors[1]).to.equal(errors.codes.SCALAR_IS_ZERO);
+            expect(verifier.errors[2]).to.equal(errors.codes.NOT_ON_CURVE);
+            expect(verifier.errors[3]).to.equal(errors.codes.NOT_ON_CURVE);
+            expect(verifier.errors[4]).to.equal(errors.codes.BAD_BLINDING_FACTOR);
+            expect(verifier.errors[5]).to.equal(errors.codes.CHALLENGE_RESPONSE_FAIL);
+        });
+    });
+});

--- a/packages/aztec.js/test/proof/publicRange/verifier.js
+++ b/packages/aztec.js/test/proof/publicRange/verifier.js
@@ -6,7 +6,6 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const { padLeft, randomHex } = require('web3-utils');
 
-
 const note = require('../../../src/note');
 const { PublicRangeProof } = require('../../../src/proof');
 const PublicRangeVerifier = require('../../../src/proof/publicRange/verifier');
@@ -26,7 +25,7 @@ describe('Public range proof verifier', () => {
     before(async () => {
         originalNote = await note.create(publicKey, originalNoteValue);
         utilityNote = await note.create(publicKey, utilityNoteValue);
-    })
+    });
     describe('Success States', () => {
         it('should verify a valid Swap proof', async () => {
             const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);

--- a/packages/contract-artifacts/src/index.js
+++ b/packages/contract-artifacts/src/index.js
@@ -21,6 +21,9 @@ const NoteUtils = require('../artifacts/NoteUtils');
 const PrivateRange = require('../artifacts/PrivateRange');
 const PrivateRangeABIEncoder = require('../artifacts/PrivateRangeABIEncoder');
 const PrivateRangeInterface = require('../artifacts/PrivateRangeInterface');
+const PublicRange = require('../artifacts/PublicRange');
+const PublicRangeABIEncoder = require('../artifacts/PublicRangeABIEncoder');
+const PublicRangeInterface = require('../artifacts/PublicRangeInterface');
 const ProofUtils = require('../artifacts/ProofUtils');
 const SafeMath8 = require('../artifacts/SafeMath8');
 const Swap = require('../artifacts/Swap');
@@ -60,6 +63,9 @@ module.exports = {
     PrivateRangeABIEncoder,
     PrivateRangeInterface,
     ProofUtils,
+    PublicRange,
+    PublicRangeABIEncoder,
+    PublicRangeInterface,
     SafeMath8,
     Swap,
     SwapABIEncoder,

--- a/packages/dev-utils/src/proofs.js
+++ b/packages/dev-utils/src/proofs.js
@@ -13,4 +13,5 @@ module.exports = {
     MINT_PROOF: '66049',
     PRIVATE_RANGE_PROOF: '66562',
     SWAP_PROOF: '65794',
+    PUBLIC_RANGE_PROOF: '66563',
 };

--- a/packages/monorepo-scripts/addresses/update.js
+++ b/packages/monorepo-scripts/addresses/update.js
@@ -10,7 +10,17 @@ const CONTRACTS_DIR = path.join(PACKAGES_PATH, 'protocol', 'build', 'contracts')
 const RINKEBY_ADDRESSES_FILE = path.join(CONTRACT_ADDRESSES_PATH, 'addresses', 'rinkeby.json');
 const ROPSTEN_ADDRESSES_FILE = path.join(CONTRACT_ADDRESSES_PATH, 'addresses', 'ropsten.json');
 
-const deployedContracts = ['ACE', 'JoinSplitFluid', 'Dividend', 'ERC20Mintable', 'JoinSplit', 'PrivateRange', 'Swap', 'ZkAsset'];
+const deployedContracts = [
+    'ACE',
+    'Dividend',
+    'ERC20Mintable',
+    'JoinSplit',
+    'JoinSplitFluid',
+    'PrivateRange',
+    'PublicRange',
+    'Swap',
+    'ZkAsset',
+];
 
 const rinkebyAddresses = {};
 const ropstenAddresses = {};

--- a/packages/monorepo-scripts/artifacts/build.js
+++ b/packages/monorepo-scripts/artifacts/build.js
@@ -6,7 +6,7 @@ const CONTRACTS_DIR = path.join(__dirname, '..', '..', 'protocol', 'build', 'con
 const ARTIFACTS_DIR = path.join(__dirname, '..', '..', 'contract-artifacts', 'artifacts');
 const ARTIFACTS_DIR_AUX = path.join(__dirname, '..', '..', 'contract-artifacts', 'artifacts-aux');
 
-const abiSwapContracts = ['JoinSplitFluid', 'Dividend', 'JoinSplit', 'PrivateRange', 'Swap'];
+const abiSwapContracts = ['Dividend', 'JoinSplit', 'JoinSplitFluid', 'PrivateRange', 'PublicRange', 'Swap'];
 const excludedContracts = ['ERC20', 'IERC20', 'Migrations', 'Ownable', 'SafeMath'];
 
 const cherrypickContractJson = async (filename) => {

--- a/packages/protocol/contracts/ACE/validators/publicRange/PublicRange.sol
+++ b/packages/protocol/contracts/ACE/validators/publicRange/PublicRange.sol
@@ -184,19 +184,18 @@ contract PublicRange {
                     // Store resulting point B at memory index b
                     result := and(result, staticcall(gas, 6, 0x160, 0x80, b, 0x40))
 
-                    // If i > 0 (i.e. if it is the utility note)
-                    // then we add \sigma^{-c} and \sigma_{acc} and store result at \sigma_{acc} (0x1e0:0x200)
-                    // we then calculate \gamma^{cx} and add into \gamma_{acc}
-                    if gt(i, 0) { // m = 0
-                        mstore(0x60, c)
-                        result := and(result, staticcall(gas, 7, 0x20, 0x60, 0x220, 0x40))
+                    // Perform the pairing check for all notes - we do this by rolling all note coordinates into the
+                    // accumulator, upon which the pairing check is performed. 
+                    // We do this adding \sigma^{-c} and \sigma_{acc} and storing the result at 
+                    // \sigma_{acc} (0x1e0:0x200). We then calculate \gamma^{cx} and add into \gamma_{acc}
+                    mstore(0x60, c)
+                    result := and(result, staticcall(gas, 7, 0x20, 0x60, 0x220, 0x40))
 
-                       // \gamma_i^{cx} now at 0x220:0x260, \gamma_{acc} is at 0x260:0x2a0
-                        result := and(result, staticcall(gas, 6, 0x220, 0x80, 0x260, 0x40))
+                    // \gamma_i^{cx} now at 0x220:0x260, \gamma_{acc} is at 0x260:0x2a0
+                    result := and(result, staticcall(gas, 6, 0x220, 0x80, 0x260, 0x40))
 
-                       // add \sigma_i^{-cx} and \sigma_{acc} into \sigma_{acc} at 0x1e0
-                        result := and(result, staticcall(gas, 6, 0x1a0, 0x80, 0x1e0, 0x40))
-                    }
+                    // add \sigma_i^{-cx} and \sigma_{acc} into \sigma_{acc} at 0x1e0
+                    result := and(result, staticcall(gas, 6, 0x1a0, 0x80, 0x1e0, 0x40))
 
                     // throw transaction if any calls to precompiled contracts failed
                     if iszero(result) { mstore(0x00, 400) revert(0x00, 0x20) }

--- a/packages/protocol/contracts/ACE/validators/publicRange/PublicRange.sol
+++ b/packages/protocol/contracts/ACE/validators/publicRange/PublicRange.sol
@@ -1,0 +1,351 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./PublicRangeABIEncoder.sol";
+import "../../../interfaces/PublicRangeInterface.sol";
+
+/**
+ * @title Library to validate AZTEC public range zero-knowledge proofs
+ * @author AZTEC
+ * @dev Don't include this as an internal library. This contract uses 
+ * a static memory table to cache elliptic curve primitives and hashes.
+ * Calling this internally from another function will lead to memory 
+ * mutation and undefined behaviour.
+ * The intended use case is to call this externally via `staticcall`. External 
+ * calls to OptimizedAZTEC can be treated as pure functions as this contract 
+ * contains no storage and makes no external calls (other than to precompiles)
+ * Copyright Spilbury Holdings Ltd 2019. All rights reserved.
+ **/
+contract PublicRange {
+
+    /**
+     * @dev PublicRange.sol will take any transaction sent to it and attempt to validate a zero knowledge proof.
+     * If the proof is not valid, the transaction throws.
+     * @notice See PublicRangeInterface for how method calls should be constructed.
+     * PublicRange.sol is written in YUL to enable manual memory management and for other efficiency savings.
+     **/
+    // solhint-disable payable-fallback
+    function() external {
+        assembly {
+
+            // We don't check for function signatures, there's only one function that 
+            // ever gets called: validatePublicRange()
+            // We still assume calldata is offset by 4 bytes so that we can represent 
+            // this contract through a compatible ABI
+            validatePublicRange()
+
+            // if we get to here, the proof is valid. We now 'fall through' the assembly block
+            // and into PublicRange.validatePublicRange()
+            // reset the free memory pointer because we're touching Solidity code again
+            mstore(0x40, 0x60)
+            /**
+             * New calldata map
+             * 0x04:0x24      = calldata location of proofData byte array 
+             * 0x24:0x44      = message sender // sender
+             * 0x44:0x64      = h_x     // crs
+             * 0x64:0x84      = h_y     // crs
+             * 0x84:0xa4      = t2_x0   // crs
+             * 0xa4:0xc4      = t2_x1   // crs
+             * 0xa4:0xc4      = t2_x1   // crs
+             * 0xc4:0xe4      = t2_y0   // crs
+             * 0xe4:0x104     = t2_y1   // crs
+             * 0x104:0x124    = length of proofData byte array 
+             * 0x124:0x144    = challenge
+             * 0x144:0x164    = publicComparison
+             * 0x164:0x184    = offset in byte array to notes
+             * 0x184:0x1a4    = offset in byte array to inputOwners
+             * 0x1a4:0x1c4    = offset in byte array to outputOwners
+             * 0x1c4:0x1e4    = offset in byte array to metadata
+             *
+             *
+             * Note data map (uint[6]) is
+             * 0x00:0x20       = Z_p element \bar{k}_i
+             * 0x20:0x40       = Z_p element \bar{a}_i
+             * 0x40:0x80       = G1 element \gamma_i
+             * 0x80:0xc0       = G1 element \sigma_i
+             *
+             * We use a hard-coded memory map to reduce gas costs - if this is not called as an 
+             * external contract then terrible things will happen!
+             *
+             * 0x00:0x20       = scratch data to store result of keccak256 calls
+             * 0x20:0x80       = scratch data to store \gamma_i and a multiplication scalar
+             * 0x80:0xc0       = x-coordinate of generator h
+             * 0xc0:0xe0       = y-coordinate of generator h
+             * 0xe0:0x100      = scratch data to store a scalar we plan to multiply h by
+             * 0x100:0x160     = scratch data to store \sigma_i and a multiplication scalar
+             * 0x160:0x1a0     = stratch data to store result of G1 point additions
+             * 0x1a0:0x1c0     = scratch data to store result of \sigma_i^{-cx_{i-m-1}}
+             * 0x220:0x260     = scratch data to store \gamma_i^{cx_{i-m-1}}
+             * 0x2e0:0x300     = msg.sender (contract should be called via delegatecall/staticcall)
+             * 0x300:???       = block of memory that contains (\gamma_i, \sigma_i)_{i=0}^{n-1} 
+             *                   concatenated with (B_i)_{i=0}^{n-1}
+             **/
+            function validatePublicRange() {
+                /*
+                ///////////////////////////////////////////  SETUP  //////////////////////////////////////////////
+                */
+
+                mstore(0x80, calldataload(0x44)) // h_x
+                mstore(0xa0, calldataload(0x64)) // h_y
+                let notes := add(0x104, calldataload(0x164)) // start position of notes
+                let n := 2
+                let m := 1
+                let gen_order := 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
+                let challenge := mod(calldataload(0x124), gen_order)
+                let publicComparison := mod(calldataload(0x144), gen_order)
+
+                mstore(0x2e0, calldataload(0x24)) // store the msg.sender, to be hashed later
+                mstore(0x300, publicComparison) 
+                mstore(0x320, 0) // add kPublic = 0 to the hash
+                mstore(0x340, 0) // add publicOwner to the hash
+                hashCommitments(notes, n)
+                let b := add(0x360, mul(n, 0x80))
+
+                /*
+                ///////////////////////////  CALCULATE BLINDING FACTORS  /////////////////////////////////////
+                */
+
+                // Iterate over every note and calculate the blinding factor B_i = \gamma_i^{kBar}h^{aBar}\sigma_i^{-c}.
+                for { let i := 0 } lt(i, n) { i := add(i, 0x01) } {
+                    // Get the calldata index of this note and associated parameters
+                    let noteIndex := add(add(notes, 0x20), mul(i, 0xc0))
+                    let k
+                    let a := calldataload(add(noteIndex, 0x20))
+                    let c := challenge
+
+                    switch gt(i, 0)
+                    case 1 {
+                        /*
+                        Enforce the condition k_2 = k_1 - c*publicComparison
+                        */
+                        k := addmod(
+                            calldataload(sub(noteIndex, 0xc0)), // k_1
+                            mulmod(sub(gen_order, c), publicComparison, gen_order), 
+                            gen_order
+                        )
+                    } 
+                        
+                    case 0 {
+                        k := calldataload(noteIndex)
+
+                    }
+
+                    // Check this commitment is well formed
+                    validateCommitment(noteIndex, k, a)
+
+                    if gt(i, 0) {
+                        // Set k = kx_j, a = ax_j, c = cx_j, where j = i - (m+1)
+                        let x := mod(mload(0x00), gen_order) // x is the kecca hash of the input commitments
+                        k := mulmod(k, x, gen_order) // kx
+                        a := mulmod(a, x, gen_order) // ax
+                        c := mulmod(challenge, x, gen_order) // cx
+                    }
+                    
+                    // Calculate the G1 element \gamma_i^{k}h^{a}\sigma_i^{-c} = B_i
+                    // Memory map:
+                    // 0x20: \gamma_iX
+                    // 0x40: \gamma_iY
+                    // 0x60: k_i
+                    // 0x80: hX
+                    // 0xa0: hY
+                    // 0xc0: a_i
+                    // 0xe0: \sigma_iX
+                    // 0x100: \sigma_iY
+                    // 0x120: -c
+
+
+                    // * Note data map (uint[6]) is
+                    // * 0x00:0x20       = Z_p element \bar{k}_i
+                    // * 0x20:0x40       = Z_p element \bar{a}_i
+                    // * 0x40:0x80       = G1 element \gamma_i
+                    // * 0x80:0xc0       = G1 element \sigma_i
+
+                    // loading into memory
+                    calldatacopy(0xe0, add(noteIndex, 0x80), 0x40)
+                    calldatacopy(0x20, add(noteIndex, 0x40), 0x40)
+                    mstore(0x120, sub(gen_order, c)) 
+                    mstore(0x60, k)
+                    mstore(0xc0, a)
+
+                    // Call bn128 scalar multiplication precompiles
+                    // Represent point + multiplication scalar in 3 consecutive blocks of memory
+                    // Store \sigma_i^{-c} at 0x1a0:0x200
+                    // Store \gamma_i^{k} at 0x120:0x160
+                    // Store h^{a} at 0x160:0x1a0
+                    let result := staticcall(gas, 7, 0xe0, 0x60, 0x1a0, 0x40) // sigmai^-c
+                    result := and(result, staticcall(gas, 7, 0x20, 0x60, 0x120, 0x40))
+                    result := and(result, staticcall(gas, 7, 0x80, 0x60, 0x160, 0x40))
+
+                    // Call bn128 group addition precompiles
+                    // \gamma_i^{k} and h^{a} in memory block 0x120:0x1a0
+                    // Store result of addition at 0x160:0x1a0
+                    result := and(result, staticcall(gas, 6, 0x120, 0x80, 0x160, 0x40))
+
+                    // \gamma_i^{k}h^{a} and \sigma^{-c} in memory block 0x160:0x1e0
+                    // Store resulting point B at memory index b
+                    result := and(result, staticcall(gas, 6, 0x160, 0x80, b, 0x40))
+
+                    // If i > 0 (i.e. if it is the utility note)
+                    // then we add \sigma^{-c} and \sigma_{acc} and store result at \sigma_{acc} (0x1e0:0x200)
+                    // we then calculate \gamma^{cx} and add into \gamma_{acc}
+                    if gt(i, 0) { // m = 0
+                        mstore(0x60, c)
+                        result := and(result, staticcall(gas, 7, 0x20, 0x60, 0x220, 0x40))
+
+                       // \gamma_i^{cx} now at 0x220:0x260, \gamma_{acc} is at 0x260:0x2a0
+                        result := and(result, staticcall(gas, 6, 0x220, 0x80, 0x260, 0x40))
+
+                       // add \sigma_i^{-cx} and \sigma_{acc} into \sigma_{acc} at 0x1e0
+                        result := and(result, staticcall(gas, 6, 0x1a0, 0x80, 0x1e0, 0x40))
+                    }
+
+                    // throw transaction if any calls to precompiled contracts failed
+                    if iszero(result) { mstore(0x00, 400) revert(0x00, 0x20) }
+                    b := add(b, 0x40) // increase B pointer by 2 words
+                }
+
+                    // Can assume by induction that k_1 is the output of a previous AZTEC transaction, and therefore 
+                    // it already satisfies a range proof. Only need to perform an explicit range check on k2
+                    validatePairing(0x84)
+            
+                /*
+                ////////////////////  RECONSTRUCT INITIAL CHALLENGE AND VERIFY A MATCH  ////////////////////////////////
+                */
+
+                // We now have the note commitments and the calculated blinding factors in a block of memory
+                // starting at 0x2e0, of size (b - 0x2e0).
+                // Hash this block to reconstruct the initial challenge and validate that they match
+                let expected := mod(keccak256(0x2e0, sub(b, 0x2e0)), gen_order)
+
+                if iszero(eq(expected, challenge)) {
+
+                    // No! Bad! No soup for you!
+                    mstore(0x00, 404)
+                    revert(0x00, 0x20)
+                }
+            }
+
+            /**
+             * @dev check that this note's points are on the altbn128 curve(y^2 = x^3 + 3)
+             * and that signatures 'k' and 'a' are modulo the order of the curve. Transaction
+             * throws if this is not the case.
+             * @param note the calldata loation of the note
+             **/
+            function validateCommitment(note, k, a) {
+                let gen_order := 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
+                let field_order := 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47
+                let gammaX := calldataload(add(note, 0x40))
+                let gammaY := calldataload(add(note, 0x60))
+                let sigmaX := calldataload(add(note, 0x80))
+                let sigmaY := calldataload(add(note, 0xa0))
+                if iszero(
+                    and(
+                        and(
+                            and(
+                                eq(mod(a, gen_order), a), // a is modulo generator order?
+                                gt(a, 1)                  // can't be 0 or 1 either!
+                            ),
+                            and(
+                                eq(mod(k, gen_order), k), // k is modulo generator order?
+                                gt(k, 1)                  // and not 0 or 1
+                            )
+                        ),
+                        and(
+                            eq( // y^2 ?= x^3 + 3
+                                addmod(mulmod(
+                                    mulmod(sigmaX, sigmaX, field_order), sigmaX, field_order), 
+                                    3, 
+                                    field_order),
+                                mulmod(sigmaY, sigmaY, field_order)
+                            ),
+                            eq( // y^2 ?= x^3 + 3
+                                addmod(mulmod(
+                                    mulmod(gammaX, gammaX, field_order), 
+                                    gammaX, 
+                                    field_order), 
+                                    3, field_order),
+                                mulmod(gammaY, gammaY, field_order)
+                            )
+                        )
+                    )
+                ) {
+                    mstore(0x00, 400)
+                    revert(0x00, 0x20)
+                }
+            }
+
+            /**        
+             * @dev evaluate if e(P1, t2) . e(P2, g2) == 0.
+             * @notice we don't hard-code t2 so that contracts that call this library can use different trusted setups.
+             **/
+            function validatePairing(t2) {
+                let field_order := 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47
+                let t2_x_1 := calldataload(t2)
+                let t2_x_2 := calldataload(add(t2, 0x20))
+                let t2_y_1 := calldataload(add(t2, 0x40))
+                let t2_y_2 := calldataload(add(t2, 0x60))
+
+                // check provided setup pubkey is not zero or g2
+                if or(or(or(or(or(or(or(
+                    iszero(t2_x_1),
+                    iszero(t2_x_2)),
+                    iszero(t2_y_1)),
+                    iszero(t2_y_2)),
+                    eq(t2_x_1, 0x1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed)),
+                    eq(t2_x_2, 0x198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2)),
+                    eq(t2_y_1, 0x12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa)),
+                    eq(t2_y_2, 0x90689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b))
+                {
+                    mstore(0x00, 400)
+                    revert(0x00, 0x20)
+                }
+
+                // store coords in memory
+                // indices are a bit off, scipr lab's libff limb ordering (c0, c1) is opposite
+                // to what precompile expects. We can overwrite the memory we used previously as this function
+                // is called at the end of the validation routine.
+                mstore(0x20, mload(0x1e0)) // sigma accumulator x
+                mstore(0x40, mload(0x200)) // sigma accumulator y
+                mstore(0x80, 0x1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed)
+                mstore(0x60, 0x198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2)
+                mstore(0xc0, 0x12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa)
+                mstore(0xa0, 0x90689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b)
+                mstore(0xe0, mload(0x260)) // gamma accumulator x
+                mstore(0x100, mload(0x280)) // gamma accumulator y
+                mstore(0x140, t2_x_1)
+                mstore(0x120, t2_x_2)
+                mstore(0x180, t2_y_1)
+                mstore(0x160, t2_y_2)
+
+                let success := staticcall(gas, 8, 0x20, 0x180, 0x20, 0x20)
+
+                if or(iszero(success), iszero(mload(0x20))) {
+                    mstore(0x00, 400)
+                    revert(0x00, 0x20)
+                }
+            }
+
+            /**
+             * @dev Calculate the keccak256 hash of the commitments for both 
+             * input notes and output notes. This is used both as an input to 
+             * validate the challenge `c` and also to generate pseudorandom relationships
+             * between commitments for different outputNotes, so that we can combine 
+             * them into a single multi-exponentiation for the purposes of validating 
+             * the bilinear pairing relationships.
+             * @param notes calldata location notes
+             * @param n number of notes
+             **/
+            function hashCommitments(notes, n) {
+                for { let i := 0 } lt(i, n) { i := add(i, 0x01) } {
+                let index := add(add(notes, mul(i, 0xc0)), 0x60)
+                calldatacopy(add(0x360, mul(i, 0x80)), index, 0x80)
+                }
+                // storing at position 0x00 in memory, the kecca hash of everything from 
+                // start of the commitments to the end
+                mstore(0x00, keccak256(0x360, mul(n, 0x80)))
+            }
+        }
+        // if we've reached here, we've validated the public range proof and haven't thrown an error.
+        // Encode the output according to the ACE standard and exit.
+        PublicRangeABIEncoder.encodeAndExit();
+    }
+}

--- a/packages/protocol/contracts/ACE/validators/publicRange/PublicRangeABIEncoder.sol
+++ b/packages/protocol/contracts/ACE/validators/publicRange/PublicRangeABIEncoder.sol
@@ -1,0 +1,218 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+/**
+ * @title Library to ABI encode the output of a public range proof verification operation
+ * @author AZTEC
+ * @dev Don't include this as an internal library. This contract uses a static memory table to cache
+ * elliptic curve primitives and hashes.
+ * Calling this internally from another function will lead to memory mutation and undefined behaviour.
+ * The intended use case is to call this externally via `staticcall`.
+ * External calls to OptimizedAZTEC can be treated as pure functions as this contract contains no
+ * storage and makes no external calls (other than to precompiles)
+ * Copyright Spilsbury Holdings Ltd 2019. All rights reserved.
+ **/
+
+library PublicRangeABIEncoder {
+    /**
+    * New calldata map
+    * 0x04:0x24      = calldata location of proofData byte array
+    * 0x24:0x44      = message sender
+    * 0x44:0x64      = h_x     // crs
+    * 0x64:0x84      = h_y     // crs
+    * 0x84:0xa4      = t2_x0   // crs
+    * 0xa4:0xc4      = t2_x1   // crs
+    * 0xc4:0xe4      = t2_y0   // crs
+    * 0xe4:0x104     = t2_y1   // crs
+    * 0x104:0x124    = length of proofData byte array
+    * 0x124:0x144    = challenge
+    * 0x144:0x164    = publicComparison
+    * 0x164:0x184    = offset in byte array to notes
+    * 0x184:0x1a4    = offset in byte array to inputOwners
+    * 0x1a4:0x1c4    = offset in byte array to outputOwners
+    * 0x1c4:0x1e4    = offset in byte array to metadata
+    */ 
+    function encodeAndExit() internal pure {
+        assembly {
+            // set up initial variables
+            let notes := add(0x104, calldataload(0x164))
+            let n := 2
+            let m := 1
+            let inputOwners := add(0x124, calldataload(0x184)) // one word after inputOwners = 1st
+            let outputOwners := add(0x124, calldataload(0x1a4)) // one word after outputOwners = 1st
+            let metadata := add(0x144, calldataload(0x1c4)) // two words after metadata = 1st
+
+            // `returndata` starts at 0x160
+            // `proofOutputs` starts at 0x180
+            // 0x160 - 0x180 = relative offset in returndata to first bytes argument (0x20)
+            // 0x180 - 0x1a0 = byte length of `proofOutputs`
+            // 0x1a0 - 0x1c0 = number of `proofOutputs` entries (1)
+            // 0x1c0 - 0x1e0 = relative memory offset between `v` and start of `proofOutput`
+
+            // `proofOutput` - t, starts at 0x1e0
+            // 0x1e0 - 0x200 = length of `proofOutput`
+            // 0x200 - 0x220 = relative offset between `t` and `inputNotes`
+            // 0x220 - 0x240 = relative offset between `t` and `outputNotes`
+            // 0x240 - 0x260 = `publicOwner`
+            // 0x260 - 0x280 = `publicValue`
+
+            // `inputNotes` starts at 0x2a0
+            // structure of `inputNotes` and `outputNotes`
+            // 0x00 - 0x20 = byte length of notes array
+            // 0x20 - 0x40 = number of notes `i`
+            // DONE the next `i` consecutive blocks of 0x20-sized memory contain relative offset between
+            // start of notes array and the location of the `note`
+
+            // structure of a `note`
+            // 0x00 - 0x20 = size of `note`
+            // 0x20 - 0x40 = `noteType`
+            // 0x40 - 0x60 = `owner`
+            // 0x60 - 0x80 = `noteHash`
+            // 0x80 - 0xa0 = size of note `data`
+            // 0xa0 - 0xc0 = compressed note coordinate `gamma` (part of `data`)
+            // 0xc0 - 0xe0 = compressed note coordinate `sigma` (part of `data`)
+            // 0xe0 - ???? = remaining note metadata
+
+            // `proofOutputs` must form a monolithic block of memory that we can return.
+            // `s` points to the memory location of the start of the current note
+            // `inputPtr` points to the start of the current `notes` dynamic bytes array
+
+            // length of proofOutputs is at s
+            mstore(0x1a0, 0x01)                            // number of proofs
+            mstore(0x1c0, 0x60)                            // offset to 1st proof
+            // length of proofOutput is at s + 0x60
+            mstore(0x200, 0xc0)                            // location of inputNotes
+            // location of outputNotes is at s + 0xc0
+            mstore(0x240, 0x00)             // publicOwner
+
+            mstore(0x260, 0) // store kPublic (public value) = 0
+
+            // 0x280 = challenge
+            mstore(0x280, calldataload(0x124))
+
+            let inputPtr := 0x2a0                                 // point to inputNotes
+            mstore(add(inputPtr, 0x20), m)                        // number of input notes
+            // set note pointer, offsetting lookup indices for each input note
+            let s := add(0x2e0, mul(m, 0x20))
+
+            for { let i := 0 } lt(i, m) { i := add(i, 0x01) } {
+                let noteIndex := add(add(notes, 0x20), mul(i, 0xc0))
+                // copy note data to 0x00 - 0x80
+                mstore(0x00, 0x01) // store note type at 0x00
+                calldatacopy(0x20, add(noteIndex, 0x40), 0x80) // get gamma, sigma
+
+
+                // store note length in `s`
+                mstore(s, 0xc0)
+                // store note type (UXTO = 1) in `s+0x20`
+                mstore(add(s, 0x20), 0x01)
+                // store note owner in `s + 0x40`
+                mstore(add(s, 0x40), calldataload(inputOwners))
+            
+                // store note hash in `s + 0x60`
+                mstore(add(s, 0x60), keccak256(0x00, 0xa0))
+
+                // store note metadata length in `s + 0x80` (just the coordinates)
+                mstore(add(s, 0x80), 0x40)
+                // store compressed note coordinate gamma in `s + 0x80`
+                mstore(
+                    add(s, 0xa0),
+                    or(
+                        calldataload(add(noteIndex, 0x40)),
+                        mul(
+                            and(calldataload(add(noteIndex, 0x60)), 0x01),
+                            0x8000000000000000000000000000000000000000000000000000000000000000
+                        )
+                    )
+                )
+                // store compressed note coordinate sigma in `s + 0xa0`
+                mstore(
+                    add(s, 0xc0),
+                    or(
+                        calldataload(add(noteIndex, 0x80)),
+                        mul(
+                            and(calldataload(add(noteIndex, 0xa0)), 0x01),
+                            0x8000000000000000000000000000000000000000000000000000000000000000
+                        )
+                    )
+                )
+                // compute the relative offset to index this note in our returndata
+                mstore(add(add(inputPtr, 0x40), mul(i, 0x20)), sub(s, inputPtr)) // relative offset to note
+        
+                // increase s by note length
+                s := add(s, 0xe0)
+            }
+
+            // store total length of inputNotes at first index of inputNotes 
+            mstore(inputPtr, sub(sub(s, inputPtr), 0x20))
+            mstore(0x220, add(0xc0, sub(s, inputPtr))) // store relative memory offset to outputNotes
+            inputPtr := s
+            mstore(add(inputPtr, 0x20), sub(n, m)) // store number of output notes
+            s := add(s, add(0x40, mul(sub(n, m), 0x20)))
+
+            // output notes
+            for { let i := m } lt(i, n) { i := add(i, 0x01) } {
+                // get note index
+                let noteIndex := add(add(notes, 0x20), mul(i, 0xc0))
+                // get pointer to metadata
+                let metadataIndex := calldataload(add(metadata, mul(sub(i, m), 0x20)))
+                // get size of metadata
+                let metadataLength := calldataload(add(sub(metadata, 0x40), metadataIndex))
+
+                mstore(0x00, 0x01) // store note type at 0x00
+                // copy note data to 0x20 - 0xa0
+                calldatacopy(0x20, add(noteIndex, 0x40), 0x80) // get gamma, sigma
+
+                // store note length in `s`
+                mstore(s, add(0xc0, metadataLength))
+                // store note type (UXTO = 1) in `s+0x20`
+                mstore(add(s, 0x20), 0x01)
+                // store the owner of the note in `s + 0x20`
+                mstore(add(s, 0x40), calldataload(add(outputOwners, mul(sub(i, m), 0x20))))
+                // store note hash
+                mstore(add(s, 0x60), keccak256(0x00, 0xa0))
+                // store note metadata length if `s + 0x60`
+                mstore(add(s, 0x80), add(0x40, metadataLength))
+                // store compressed note coordinate gamma in `s + 0x80`
+                mstore(
+                    add(s, 0xa0),
+                    or(
+                        mload(0x20),
+                        mul(
+                            and(mload(0x40), 0x01),
+                            0x8000000000000000000000000000000000000000000000000000000000000000
+                        )
+                    )
+                )
+                // store compressed note coordinate sigma in `s + 0xa0`
+                mstore(
+                add(s, 0xc0),
+                or(
+                    mload(0x60),
+                    mul(
+                        and(mload(0x80), 0x01),
+                        0x8000000000000000000000000000000000000000000000000000000000000000
+                    )
+                )
+                )
+                // copy metadata into `s + 0xc0`
+                calldatacopy(add(s, 0xe0), add(metadataIndex, sub(metadata, 0x20)), metadataLength)
+                // compute the relative offset to index this note in our returndata
+                mstore(add(add(inputPtr, 0x40), mul(sub(i, m), 0x20)), sub(s, inputPtr)) // relative offset to note
+
+                // increase s by note length
+                s := add(s, add(mload(s), 0x20))
+            }
+
+            // cleanup. the length of the outputNotes = s - inputPtr
+            mstore(inputPtr, sub(sub(s, inputPtr), 0x20)) // store length of outputNotes at start of outputNotes
+            let notesLength := sub(s, 0x2a0)
+            // store length of proofOutput at 0x160. 0xa0 comes from:
+            // (offset to input notes, offset to output notes, publicOwner, publicValue, challenge)
+            mstore(0x1e0, add(0xa0, notesLength))
+            mstore(0x180, add(0x100, notesLength)) // store length of proofOutputs at 0x100
+
+            mstore(0x160, 0x20)
+            return(0x160, add(0x140, notesLength)) // return the final byte array
+        }
+    }
+}

--- a/packages/protocol/contracts/interfaces/IAZTEC.sol
+++ b/packages/protocol/contracts/interfaces/IAZTEC.sol
@@ -30,10 +30,13 @@ contract IAZTEC {
     // (1 * 256**(2)) + (4 * 256**(1)) + (2 * 256**(0))
     uint24 public constant PRIVATE_RANGE_PROOF = 66562;
 
+        // proofEpoch = 1 | proofCategory = 4 | proofId = 3
+    // (1 * 256**(2)) + (4 * 256**(1)) + (2 * 256**(0))
+    uint24 public constant PUBLIC_RANGE_PROOF = 66563;
+
     // proofEpoch = 1 | proofCategory = 4 | proofId = 1
     // (1 * 256**(2)) + (4 * 256**(1)) + (2 * 256**(0))
     uint24 public constant DIVIDEND_PROOF = 66561;
-
 
     // Hash of a dummy AZTEC note with k = 0 and a = 1
     bytes32 public constant ZERO_VALUE_NOTE_HASH = 0xcbc417524e52b95c42a4c42d357938497e3d199eb9b4a0139c92551d4000bc3c;

--- a/packages/protocol/contracts/interfaces/PublicRangeInterface.sol
+++ b/packages/protocol/contracts/interfaces/PublicRangeInterface.sol
@@ -1,0 +1,17 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+/**
+ * @title PublicRangeInterface
+ * @author AZTEC
+ * @dev An interface defining the PublicRangeInterface standard.
+ * Copyright Spilbury Holdings Ltd 2019. All rights reserved.
+ **/
+interface PublicRangeInterface {
+    /* solhint-disable-next-line var-name-mixedcase */
+    
+    function validatePublicRange(
+        bytes calldata, 
+        address, 
+        uint[6] calldata
+    ) external pure returns (bytes memory);
+}

--- a/packages/protocol/contracts/test/ACE/validators/publicRange/PublicRangeABIEncoderTest.sol
+++ b/packages/protocol/contracts/test/ACE/validators/publicRange/PublicRangeABIEncoderTest.sol
@@ -1,0 +1,17 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "../../../../ACE/validators/publicRange/PublicRangeABIEncoder.sol";
+import "../../../../libs/LibEIP712.sol";
+
+contract PublicRangeABIEncoderTest {
+    function validatePublicRange(
+        bytes calldata,
+        address,
+        uint[6] calldata
+    )
+        external pure
+        returns (bytes memory)
+    {
+        PublicRangeABIEncoder.encodeAndExit();
+    }
+}

--- a/packages/protocol/test/ACE/validators/dividend/abiEncoder.js
+++ b/packages/protocol/test/ACE/validators/dividend/abiEncoder.js
@@ -61,6 +61,4 @@ contract('Dividend ABI Encoder', (accounts) => {
         expect(decoded[0].publicValue).to.equal(proof.publicValue.toNumber());
         expect(decoded[0].challenge).to.equal(proof.challengeHex);
     });
-
-    describe('Success States', () => {});
 });

--- a/packages/protocol/test/ACE/validators/publicRange/abiEncoder.js
+++ b/packages/protocol/test/ACE/validators/publicRange/abiEncoder.js
@@ -1,0 +1,58 @@
+/* global artifacts, expect, contract, it:true */
+const { PublicRangeProof, encoder, note } = require('aztec.js');
+const bn128 = require('@aztec/bn128');
+const { padLeft } = require('web3-utils');
+const secp256k1 = require('@aztec/secp256k1');
+
+const PublicRangeABIEncoderTest = artifacts.require('./PublicRangeABIEncoderTest');
+
+let publicRangeAbiEncoderTest;
+const { publicKey } = secp256k1.generateAccount();
+
+const getNotes = async (originalNoteValue, utilityNoteValue) => {
+    const originalNote = await note.create(publicKey, originalNoteValue);
+    const utilityNote = await note.create(publicKey, utilityNoteValue);
+    return { originalNote, utilityNote };
+};
+
+const getDefaultNotes = async () => {
+    const originalNoteValue = 50;
+    const utilityNoteValue = 40;
+    const publicInteger = 10;
+    const isGreaterOrEqual = true;
+
+    const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
+    return { originalNote, utilityNote, publicInteger, isGreaterOrEqual };
+};
+
+contract('Public range ABI Encoder', (accounts) => {
+    const sender = accounts[0];
+
+    before(async () => {
+        publicRangeAbiEncoderTest = await PublicRangeABIEncoderTest.new({ from: sender });
+    });
+
+    it('should encode output of public range proof', async () => {
+        const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+
+        const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+        const data = proof.encodeABI();
+        const result = await publicRangeAbiEncoderTest.validatePublicRange(data, sender, bn128.CRS);
+        const decoded = encoder.outputCoder.decodeProofOutputs(`0x${padLeft('0', 64)}${result.slice(2)}`);
+        expect(result).to.equal(proof.eth.outputs);
+
+        expect(decoded[0].inputNotes[0].gamma.eq(originalNote.gamma)).to.equal(true);
+        expect(decoded[0].inputNotes[0].sigma.eq(originalNote.sigma)).to.equal(true);
+        expect(decoded[0].inputNotes[0].noteHash).to.equal(originalNote.noteHash);
+        expect(decoded[0].inputNotes[0].owner).to.equal(originalNote.owner.toLowerCase());
+
+        expect(decoded[0].outputNotes[0].gamma.eq(utilityNote.gamma)).to.equal(true);
+        expect(decoded[0].outputNotes[0].sigma.eq(utilityNote.sigma)).to.equal(true);
+        expect(decoded[0].outputNotes[0].noteHash).to.equal(utilityNote.noteHash);
+        expect(decoded[0].outputNotes[0].owner).to.equal(utilityNote.owner.toLowerCase());
+
+        expect(decoded[0].publicOwner).to.equal(proof.publicOwner.toLowerCase());
+        expect(decoded[0].publicValue).to.equal(proof.publicValue.toNumber());
+        expect(decoded[0].challenge).to.equal(proof.challengeHex);
+    });
+});

--- a/packages/protocol/test/ACE/validators/publicRange/abiEncoder.js
+++ b/packages/protocol/test/ACE/validators/publicRange/abiEncoder.js
@@ -18,11 +18,11 @@ const getNotes = async (originalNoteValue, utilityNoteValue) => {
 const getDefaultNotes = async () => {
     const originalNoteValue = 50;
     const utilityNoteValue = 40;
-    const publicInteger = 10;
+    const publicComparison = 10;
     const isGreaterOrEqual = true;
 
     const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
-    return { originalNote, utilityNote, publicInteger, isGreaterOrEqual };
+    return { originalNote, utilityNote, publicComparison, isGreaterOrEqual };
 };
 
 contract('Public range ABI Encoder', (accounts) => {
@@ -33,9 +33,9 @@ contract('Public range ABI Encoder', (accounts) => {
     });
 
     it('should encode output of public range proof', async () => {
-        const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+        const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultNotes();
 
-        const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+        const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
         const data = proof.encodeABI();
         const result = await publicRangeAbiEncoderTest.validatePublicRange(data, sender, bn128.CRS);
         const decoded = encoder.outputCoder.decodeProofOutputs(`0x${padLeft('0', 64)}${result.slice(2)}`);

--- a/packages/protocol/test/ACE/validators/publicRange/index.js
+++ b/packages/protocol/test/ACE/validators/publicRange/index.js
@@ -47,7 +47,7 @@ contract('Public range validator', (accounts) => {
         publicRangeValidator = await PublicRange.new({ from: sender });
     });
 
-    describe('greater than tests', () => {
+    describe('Greater than tests', () => {
         describe('Success states', () => {
             it('should validate public range proof when given explicit utilityNote', async () => {
                 const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
@@ -87,7 +87,7 @@ contract('Public range validator', (accounts) => {
                 const utilityNoteValue = 41;
                 const publicComparison = 10;
                 const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
-                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote, false);
                 const data = proof.encodeABI();
                 await truffleAssert.reverts(
                     publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
@@ -101,7 +101,7 @@ contract('Public range validator', (accounts) => {
                 const utilityNoteValue = 0;
                 const publicComparison = 10;
                 const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
-                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote, false);
                 const data = proof.encodeABI();
                 await truffleAssert.reverts(
                     publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
@@ -370,7 +370,7 @@ contract('Public range validator', (accounts) => {
                 const utilityNoteValue = 0;
                 const publicComparison = 20;
                 const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
-                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote, false);
                 const data = proof.encodeABI();
                 await truffleAssert.reverts(
                     publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
@@ -381,7 +381,7 @@ contract('Public range validator', (accounts) => {
             it('should fail for a less than proof, when a greater than proof is specified', async () => {
                 const isGreaterOrEqual = true;
                 const { originalNote, utilityNote, publicComparison } = await getDefaultLessThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote, false);
                 const data = proof.encodeABI();
                 await truffleAssert.reverts(
                     publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),

--- a/packages/protocol/test/ACE/validators/publicRange/index.js
+++ b/packages/protocol/test/ACE/validators/publicRange/index.js
@@ -26,18 +26,18 @@ const getDefaultGreaterThanNotes = async () => {
     const isGreaterOrEqual = true;
     const originalNoteValue = 50;
     const utilityNoteValue = 40;
-    const publicInteger = 10;
+    const publicComparison = 10;
     const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
-    return { originalNote, utilityNote, publicInteger, isGreaterOrEqual };
+    return { originalNote, utilityNote, publicComparison, isGreaterOrEqual };
 };
 
 const getDefaultLessThanNotes = async () => {
     const isGreaterOrEqual = false;
     const originalNoteValue = 10;
     const utilityNoteValue = 30;
-    const publicInteger = 20;
+    const publicComparison = 20;
     const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
-    return { originalNote, utilityNote, publicInteger, isGreaterOrEqual };
+    return { originalNote, utilityNote, publicComparison, isGreaterOrEqual };
 };
 
 contract('Public range validator', (accounts) => {
@@ -50,8 +50,8 @@ contract('Public range validator', (accounts) => {
     describe('greater than tests', () => {
         describe('Success states', () => {
             it('should validate public range proof when given explicit utilityNote', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 const data = proof.encodeABI();
                 const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS, { from: sender });
                 expect(result).to.equal(proof.eth.outputs);
@@ -61,17 +61,17 @@ contract('Public range validator', (accounts) => {
                 const isGreaterOrEqual = true;
                 const originalNoteValue = 10;
                 const utilityNoteValue = 0;
-                const publicInteger = 10;
+                const publicComparison = 10;
                 const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 const data = proof.encodeABI();
                 const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS);
                 expect(result).to.equal(proof.eth.outputs);
             });
 
             it('should validate public range proof with challenge that has group modulus added to it', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 proof.challenge = proof.challenge.add(bn128.groupModulus);
                 proof.constructOutputs(); // why do we have to do this?
                 const data = proof.encodeABI();
@@ -85,8 +85,9 @@ contract('Public range validator', (accounts) => {
                 const isGreaterOrEqual = true;
                 const originalNoteValue = 50;
                 const utilityNoteValue = 41;
-                const { originalNote, utilityNote, publicInteger } = await getNotes(originalNoteValue, utilityNoteValue);
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const publicComparison = 10;
+                const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 const data = proof.encodeABI();
                 await truffleAssert.reverts(
                     publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
@@ -98,9 +99,9 @@ contract('Public range validator', (accounts) => {
                 const isGreaterOrEqual = true;
                 const originalNoteValue = 9;
                 const utilityNoteValue = 0;
-                const publicInteger = 10;
+                const publicComparison = 10;
                 const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 const data = proof.encodeABI();
                 await truffleAssert.reverts(
                     publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
@@ -109,8 +110,8 @@ contract('Public range validator', (accounts) => {
             });
 
             it('should fail for random proof data', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 proof.data = [];
                 for (let i = 0; i < 2; i += 1) {
                     proof.data[i] = [];
@@ -126,8 +127,8 @@ contract('Public range validator', (accounts) => {
             });
 
             it('should fail for fake challenge', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 proof.challenge = new BN('0');
                 const data = proof.encodeABI();
                 await truffleAssert.reverts(
@@ -137,8 +138,8 @@ contract('Public range validator', (accounts) => {
             });
 
             it('should fail if scalars are NOT mod(GROUP_MODULUS)', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 const kBar = new BN(proof.data[0][0].slice(2), 16);
                 const notModRKBar = `0x${kBar.add(bn128.groupModulus).toString(16)}`;
                 proof.data[0][0] = notModRKBar;
@@ -150,8 +151,8 @@ contract('Public range validator', (accounts) => {
             });
 
             it('should fail if blinding factor resolves to point at infinity', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 proof.data[0][0] = padLeft('0x05', 64);
                 proof.data[0][1] = padLeft('0x05', 64);
                 proof.data[0][2] = `0x${bn128.H_X.toString(16)}`;
@@ -167,8 +168,8 @@ contract('Public range validator', (accounts) => {
             });
 
             it('should fail if scalars are zero', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 const zeroScalar = padLeft('0x00', 64);
                 proof.data[0][0] = zeroScalar;
                 proof.data[0][1] = zeroScalar;
@@ -182,8 +183,8 @@ contract('Public range validator', (accounts) => {
             });
 
             it('should fail for incorrect H_X, H_Y in CRS', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 const malformedHx = bn128.H_X.add(new BN(1));
                 const malformedHy = bn128.H_Y.add(new BN(1));
                 const malformedCRS = [`0x${malformedHx.toString(16)}`, `0x${malformedHy.toString(16)}`, ...bn128.t2];
@@ -195,8 +196,8 @@ contract('Public range validator', (accounts) => {
             });
 
             it('should fail if provided 0 notes', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 proof.data = [];
                 const data = proof.encodeABI();
                 await truffleAssert.reverts(
@@ -206,12 +207,12 @@ contract('Public range validator', (accounts) => {
             });
 
             it('should fail if sender NOT integrated into challenge variable', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 // First element should have been the sender
                 proof.challengeHash = new Keccak();
                 proof.constructChallengeRecurse([
-                    proof.publicInteger,
+                    proof.publicComparison,
                     proof.publicValue,
                     proof.publicOwner,
                     proof.notes,
@@ -225,10 +226,10 @@ contract('Public range validator', (accounts) => {
                 );
             });
 
-            it('should fail if publicInteger NOT integrated into challenge variable', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-                // Second element should have been the publicInteger
+            it('should fail if publicComparison NOT integrated into challenge variable', async () => {
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
+                // Second element should have been the publicComparison
                 proof.challengeHash = new Keccak();
                 proof.constructChallengeRecurse([
                     proof.sender,
@@ -246,13 +247,13 @@ contract('Public range validator', (accounts) => {
             });
 
             it('should fail if publicValue NOT integrated into challenge variable', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 // Third element should have been the publicValue
                 proof.challengeHash = new Keccak();
                 proof.constructChallengeRecurse([
                     proof.sender,
-                    proof.publicInteger,
+                    proof.publicComparison,
                     proof.publicOwner,
                     proof.notes,
                     proof.blindingFactors,
@@ -266,13 +267,13 @@ contract('Public range validator', (accounts) => {
             });
 
             it('should fail if publicOwner NOT integrated into challenge variable', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 // Fourth element should have been the publicOwner
                 proof.challengeHash = new Keccak();
                 proof.constructChallengeRecurse([
                     proof.sender,
-                    proof.publicInteger,
+                    proof.publicComparison,
                     proof.publicValue,
                     proof.notes,
                     proof.blindingFactors,
@@ -286,13 +287,13 @@ contract('Public range validator', (accounts) => {
             });
 
             it('should fail if notes NOT integrated into challenge variable', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 // Fifth element should have been the notes
                 proof.challengeHash = new Keccak();
                 proof.constructChallengeRecurse([
                     proof.sender,
-                    proof.publicInteger,
+                    proof.publicComparison,
                     proof.publicValue,
                     proof.publicOwner,
                     proof.blindingFactors,
@@ -306,13 +307,13 @@ contract('Public range validator', (accounts) => {
             });
 
             it('should fail if blindingFactors NOT integrated into challenge variable', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 // Sixth element should have been the blindingFactors
                 proof.challengeHash = new Keccak();
                 proof.constructChallengeRecurse([
                     proof.sender,
-                    proof.publicInteger,
+                    proof.publicComparison,
                     proof.publicValue,
                     proof.publicOwner,
                     proof.notes,
@@ -326,8 +327,8 @@ contract('Public range validator', (accounts) => {
             });
 
             it('should fail if points are NOT on the curve', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 const zeroPublicRangeProof = await mockZeroPublicRangeProof();
                 proof.data = zeroPublicRangeProof.data;
                 const data = proof.encodeABI();
@@ -342,20 +343,20 @@ contract('Public range validator', (accounts) => {
     describe('Less than tests', () => {
         describe('Success states', () => {
             it('should validate a less than proof', async () => {
-                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultLessThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison, isGreaterOrEqual } = await getDefaultLessThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 const data = proof.encodeABI();
                 const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS, { from: sender });
                 expect(result).to.equal(proof.eth.outputs);
             });
 
-            it('should succeed for originalValue = publicInteger, when making a less than or equal to', async () => {
+            it('should succeed for originalValue = publicComparison, when making a less than or equal to', async () => {
                 const isGreaterOrEqual = false;
                 const originalNoteValue = 20;
                 const utilityNoteValue = 40;
-                const publicInteger = 20;
+                const publicComparison = 20;
                 const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 const data = proof.encodeABI();
                 const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS, { from: sender });
                 expect(result).to.equal(proof.eth.outputs);
@@ -367,9 +368,9 @@ contract('Public range validator', (accounts) => {
                 const isGreaterOrEqual = false;
                 const originalNoteValue = 20;
                 const utilityNoteValue = 0;
-                const publicInteger = 20;
+                const publicComparison = 20;
                 const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 const data = proof.encodeABI();
                 await truffleAssert.reverts(
                     publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
@@ -379,8 +380,8 @@ contract('Public range validator', (accounts) => {
 
             it('should fail for a less than proof, when a greater than proof is specified', async () => {
                 const isGreaterOrEqual = true;
-                const { originalNote, utilityNote, publicInteger } = await getDefaultLessThanNotes();
-                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const { originalNote, utilityNote, publicComparison } = await getDefaultLessThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicComparison, sender, isGreaterOrEqual, utilityNote);
                 const data = proof.encodeABI();
                 await truffleAssert.reverts(
                     publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),

--- a/packages/protocol/test/ACE/validators/publicRange/index.js
+++ b/packages/protocol/test/ACE/validators/publicRange/index.js
@@ -1,0 +1,329 @@
+/* global artifacts, expect, contract, it:true */
+const { PublicRangeProof, note, keccak } = require('aztec.js');
+const bn128 = require('@aztec/bn128');
+const secp256k1 = require('@aztec/secp256k1');
+const BN = require('bn.js');
+const truffleAssert = require('truffle-assertions');
+const { padLeft, randomHex } = require('web3-utils');
+
+const { mockZeroPublicRangeProof } = require('../../../helpers/proof');
+
+const PublicRange = artifacts.require('./PublicRange');
+const PublicRangeInterface = artifacts.require('./PublicRangeInterface');
+PublicRange.abi = PublicRangeInterface.abi;
+
+const Keccak = keccak;
+let publicRangeValidator;
+const { publicKey } = secp256k1.generateAccount();
+
+const getNotes = async (originalNoteValue, utilityNoteValue) => {
+    const isGreaterOrEqual = true;
+    const originalNote = await note.create(publicKey, originalNoteValue);
+    const utilityNote = await note.create(publicKey, utilityNoteValue);
+    return { originalNote, utilityNote, isGreaterOrEqual };
+};
+
+const getDefaultNotes = async () => {
+    const originalNoteValue = 50;
+    const utilityNoteValue = 40;
+    const publicInteger = 10;
+    const { originalNote, utilityNote, isGreaterOrEqual } = await getNotes(originalNoteValue, utilityNoteValue);
+    return { originalNote, utilityNote, publicInteger, isGreaterOrEqual };
+};
+
+contract('Public range validator', (accounts) => {
+    const sender = accounts[0];
+
+    before(async () => {
+        publicRangeValidator = await PublicRange.new({ from: sender });
+    });
+    describe('Success states', () => {
+        it('should validate public range proof', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            const data = proof.encodeABI();
+            const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS, { from: sender });
+            expect(result).to.equal(proof.eth.outputs);
+        });
+
+        it('should validate public range proof for note of zero value', async () => {
+            const originalNoteValue = 10;
+            const utilityNoteValue = 0;
+            const publicInteger = 10;
+            const { originalNote, utilityNote, isGreaterOrEqual } = await getNotes(originalNoteValue, utilityNoteValue);
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            const data = proof.encodeABI();
+            const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS);
+            expect(result).to.equal(proof.eth.outputs);
+        });
+
+        it('should validate public range proof with challenge that has group modulus added to it', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            proof.challenge = proof.challenge.add(bn128.groupModulus);
+            proof.constructOutputs(); // why do we have to do this?
+            const data = proof.encodeABI();
+            const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS);
+            expect(result).to.equal(proof.eth.outputs);
+        });
+    });
+
+    describe('Failure states', () => {
+        it('should fail if notes do NOT balance', async () => {
+            const originalNoteValue = 50;
+            const utilityNoteValue = 41;
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getNotes(
+                originalNoteValue,
+                utilityNoteValue,
+            );
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it('should fail when note value is less than public integer', async () => {
+            const originalNoteValue = 9;
+            const utilityNoteValue = 0;
+            const publicInteger = 10;
+            const { originalNote, utilityNote, isGreaterOrEqual } = await getNotes(originalNoteValue, utilityNoteValue);
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it('should fail for random proof data', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            proof.data = [];
+            for (let i = 0; i < 2; i += 1) {
+                proof.data[i] = [];
+                for (let j = 0; j < 6; j += 1) {
+                    proof.data[i][j] = randomHex(32);
+                }
+            }
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it('should fail for fake challenge', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            proof.challenge = new BN('0');
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it('should fail if scalars are NOT mod(GROUP_MODULUS)', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            const kBar = new BN(proof.data[0][0].slice(2), 16);
+            const notModRKBar = `0x${kBar.add(bn128.groupModulus).toString(16)}`;
+            proof.data[0][0] = notModRKBar;
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it('should fail if blinding factor resolves to point at infinity', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            proof.data[0][0] = padLeft('0x05', 64);
+            proof.data[0][1] = padLeft('0x05', 64);
+            proof.data[0][2] = `0x${bn128.H_X.toString(16)}`;
+            proof.data[0][3] = `0x${bn128.H_Y.toString(16)}`;
+            proof.data[0][4] = `0x${bn128.H_X.toString(16)}`;
+            proof.data[0][5] = `0x${bn128.H_Y.toString(16)}`;
+            proof.challenge = new BN('0a', 16);
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it('should fail if scalars are zero', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            const zeroScalar = padLeft('0x00', 64);
+            proof.data[0][0] = zeroScalar;
+            proof.data[0][1] = zeroScalar;
+            proof.data[1][0] = zeroScalar;
+            proof.data[1][1] = zeroScalar;
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it('should fail for incorrect H_X, H_Y in CRS', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            const malformedHx = bn128.H_X.add(new BN(1));
+            const malformedHy = bn128.H_Y.add(new BN(1));
+            const malformedCRS = [`0x${malformedHx.toString(16)}`, `0x${malformedHy.toString(16)}`, ...bn128.t2];
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, malformedCRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it('should fail if provided 0 notes', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            proof.data = [];
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it('should fail if sender NOT integrated into challenge variable', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            // First element should have been the sender
+            proof.challengeHash = new Keccak();
+            proof.constructChallengeRecurse([
+                proof.publicInteger,
+                proof.publicValue,
+                proof.publicOwner,
+                proof.notes,
+                proof.blindingFactors,
+            ]);
+            proof.challenge = proof.challengeHash.redKeccak();
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it('should fail if publicInteger NOT integrated into challenge variable', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            // Second element should have been the publicInteger
+            proof.challengeHash = new Keccak();
+            proof.constructChallengeRecurse([
+                proof.sender,
+                proof.publicValue,
+                proof.publicOwner,
+                proof.notes,
+                proof.blindingFactors,
+            ]);
+            proof.challenge = proof.challengeHash.redKeccak();
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it('should fail if publicValue NOT integrated into challenge variable', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            // Third element should have been the publicValue
+            proof.challengeHash = new Keccak();
+            proof.constructChallengeRecurse([
+                proof.sender,
+                proof.publicInteger,
+                proof.publicOwner,
+                proof.notes,
+                proof.blindingFactors,
+            ]);
+            proof.challenge = proof.challengeHash.redKeccak();
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it('should fail if publicOwner NOT integrated into challenge variable', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            // Fourth element should have been the publicOwner
+            proof.challengeHash = new Keccak();
+            proof.constructChallengeRecurse([
+                proof.sender,
+                proof.publicInteger,
+                proof.publicValue,
+                proof.notes,
+                proof.blindingFactors,
+            ]);
+            proof.challenge = proof.challengeHash.redKeccak();
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it('should fail if notes NOT integrated into challenge variable', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            // Fifth element should have been the notes
+            proof.challengeHash = new Keccak();
+            proof.constructChallengeRecurse([
+                proof.sender,
+                proof.publicInteger,
+                proof.publicValue,
+                proof.publicOwner,
+                proof.blindingFactors,
+            ]);
+            proof.challenge = proof.challengeHash.redKeccak();
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it('should fail if blindingFactors NOT integrated into challenge variable', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            // Sixth element should have been the blindingFactors
+            proof.challengeHash = new Keccak();
+            proof.constructChallengeRecurse([
+                proof.sender,
+                proof.publicInteger,
+                proof.publicValue,
+                proof.publicOwner,
+                proof.notes,
+            ]);
+            proof.challenge = proof.challengeHash.redKeccak();
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
+        it.only('should fail if points are NOT on the curve', async () => {
+            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
+            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+            const zeroPublicRangeProof = await mockZeroPublicRangeProof();
+            proof.data = zeroPublicRangeProof.data;
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+    });
+});

--- a/packages/protocol/test/ACE/validators/publicRange/index.js
+++ b/packages/protocol/test/ACE/validators/publicRange/index.js
@@ -1,7 +1,7 @@
 /* global artifacts, expect, contract, it:true */
 const { PublicRangeProof, note, keccak } = require('aztec.js');
-const bn128 = require('@aztec/bn128');
 const secp256k1 = require('@aztec/secp256k1');
+const bn128 = require('@aztec/bn128');
 const BN = require('bn.js');
 const truffleAssert = require('truffle-assertions');
 const { padLeft, randomHex } = require('web3-utils');
@@ -17,17 +17,26 @@ let publicRangeValidator;
 const { publicKey } = secp256k1.generateAccount();
 
 const getNotes = async (originalNoteValue, utilityNoteValue) => {
-    const isGreaterOrEqual = true;
     const originalNote = await note.create(publicKey, originalNoteValue);
     const utilityNote = await note.create(publicKey, utilityNoteValue);
-    return { originalNote, utilityNote, isGreaterOrEqual };
+    return { originalNote, utilityNote };
 };
 
-const getDefaultNotes = async () => {
+const getDefaultGreaterThanNotes = async () => {
+    const isGreaterOrEqual = true;
     const originalNoteValue = 50;
     const utilityNoteValue = 40;
     const publicInteger = 10;
-    const { originalNote, utilityNote, isGreaterOrEqual } = await getNotes(originalNoteValue, utilityNoteValue);
+    const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
+    return { originalNote, utilityNote, publicInteger, isGreaterOrEqual };
+};
+
+const getDefaultLessThanNotes = async () => {
+    const isGreaterOrEqual = false;
+    const originalNoteValue = 10;
+    const utilityNoteValue = 30;
+    const publicInteger = 20;
+    const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
     return { originalNote, utilityNote, publicInteger, isGreaterOrEqual };
 };
 
@@ -37,293 +46,347 @@ contract('Public range validator', (accounts) => {
     before(async () => {
         publicRangeValidator = await PublicRange.new({ from: sender });
     });
-    describe('Success states', () => {
-        it('should validate public range proof', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            const data = proof.encodeABI();
-            const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS, { from: sender });
-            expect(result).to.equal(proof.eth.outputs);
+
+    describe('greater than tests', () => {
+        describe('Success states', () => {
+            it('should validate public range proof when given explicit utilityNote', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const data = proof.encodeABI();
+                const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS, { from: sender });
+                expect(result).to.equal(proof.eth.outputs);
+            });
+
+            it('should validate public range proof for note of zero value', async () => {
+                const isGreaterOrEqual = true;
+                const originalNoteValue = 10;
+                const utilityNoteValue = 0;
+                const publicInteger = 10;
+                const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const data = proof.encodeABI();
+                const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS);
+                expect(result).to.equal(proof.eth.outputs);
+            });
+
+            it('should validate public range proof with challenge that has group modulus added to it', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                proof.challenge = proof.challenge.add(bn128.groupModulus);
+                proof.constructOutputs(); // why do we have to do this?
+                const data = proof.encodeABI();
+                const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS);
+                expect(result).to.equal(proof.eth.outputs);
+            });
         });
 
-        it('should validate public range proof for note of zero value', async () => {
-            const originalNoteValue = 10;
-            const utilityNoteValue = 0;
-            const publicInteger = 10;
-            const { originalNote, utilityNote, isGreaterOrEqual } = await getNotes(originalNoteValue, utilityNoteValue);
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            const data = proof.encodeABI();
-            const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS);
-            expect(result).to.equal(proof.eth.outputs);
-        });
+        describe('Failure states', () => {
+            it('should fail if notes do NOT balance', async () => {
+                const isGreaterOrEqual = true;
+                const originalNoteValue = 50;
+                const utilityNoteValue = 41;
+                const { originalNote, utilityNote, publicInteger } = await getNotes(originalNoteValue, utilityNoteValue);
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
 
-        it('should validate public range proof with challenge that has group modulus added to it', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            proof.challenge = proof.challenge.add(bn128.groupModulus);
-            proof.constructOutputs(); // why do we have to do this?
-            const data = proof.encodeABI();
-            const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS);
-            expect(result).to.equal(proof.eth.outputs);
+            it('should fail when note value is less than public integer', async () => {
+                const isGreaterOrEqual = true;
+                const originalNoteValue = 9;
+                const utilityNoteValue = 0;
+                const publicInteger = 10;
+                const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
+
+            it('should fail for random proof data', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                proof.data = [];
+                for (let i = 0; i < 2; i += 1) {
+                    proof.data[i] = [];
+                    for (let j = 0; j < 6; j += 1) {
+                        proof.data[i][j] = randomHex(32);
+                    }
+                }
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
+
+            it('should fail for fake challenge', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                proof.challenge = new BN('0');
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
+
+            it('should fail if scalars are NOT mod(GROUP_MODULUS)', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const kBar = new BN(proof.data[0][0].slice(2), 16);
+                const notModRKBar = `0x${kBar.add(bn128.groupModulus).toString(16)}`;
+                proof.data[0][0] = notModRKBar;
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
+
+            it('should fail if blinding factor resolves to point at infinity', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                proof.data[0][0] = padLeft('0x05', 64);
+                proof.data[0][1] = padLeft('0x05', 64);
+                proof.data[0][2] = `0x${bn128.H_X.toString(16)}`;
+                proof.data[0][3] = `0x${bn128.H_Y.toString(16)}`;
+                proof.data[0][4] = `0x${bn128.H_X.toString(16)}`;
+                proof.data[0][5] = `0x${bn128.H_Y.toString(16)}`;
+                proof.challenge = new BN('0a', 16);
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
+
+            it('should fail if scalars are zero', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const zeroScalar = padLeft('0x00', 64);
+                proof.data[0][0] = zeroScalar;
+                proof.data[0][1] = zeroScalar;
+                proof.data[1][0] = zeroScalar;
+                proof.data[1][1] = zeroScalar;
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
+
+            it('should fail for incorrect H_X, H_Y in CRS', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const malformedHx = bn128.H_X.add(new BN(1));
+                const malformedHy = bn128.H_Y.add(new BN(1));
+                const malformedCRS = [`0x${malformedHx.toString(16)}`, `0x${malformedHy.toString(16)}`, ...bn128.t2];
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, malformedCRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
+
+            it('should fail if provided 0 notes', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                proof.data = [];
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
+
+            it('should fail if sender NOT integrated into challenge variable', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                // First element should have been the sender
+                proof.challengeHash = new Keccak();
+                proof.constructChallengeRecurse([
+                    proof.publicInteger,
+                    proof.publicValue,
+                    proof.publicOwner,
+                    proof.notes,
+                    proof.blindingFactors,
+                ]);
+                proof.challenge = proof.challengeHash.redKeccak();
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
+
+            it('should fail if publicInteger NOT integrated into challenge variable', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                // Second element should have been the publicInteger
+                proof.challengeHash = new Keccak();
+                proof.constructChallengeRecurse([
+                    proof.sender,
+                    proof.publicValue,
+                    proof.publicOwner,
+                    proof.notes,
+                    proof.blindingFactors,
+                ]);
+                proof.challenge = proof.challengeHash.redKeccak();
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
+
+            it('should fail if publicValue NOT integrated into challenge variable', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                // Third element should have been the publicValue
+                proof.challengeHash = new Keccak();
+                proof.constructChallengeRecurse([
+                    proof.sender,
+                    proof.publicInteger,
+                    proof.publicOwner,
+                    proof.notes,
+                    proof.blindingFactors,
+                ]);
+                proof.challenge = proof.challengeHash.redKeccak();
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
+
+            it('should fail if publicOwner NOT integrated into challenge variable', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                // Fourth element should have been the publicOwner
+                proof.challengeHash = new Keccak();
+                proof.constructChallengeRecurse([
+                    proof.sender,
+                    proof.publicInteger,
+                    proof.publicValue,
+                    proof.notes,
+                    proof.blindingFactors,
+                ]);
+                proof.challenge = proof.challengeHash.redKeccak();
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
+
+            it('should fail if notes NOT integrated into challenge variable', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                // Fifth element should have been the notes
+                proof.challengeHash = new Keccak();
+                proof.constructChallengeRecurse([
+                    proof.sender,
+                    proof.publicInteger,
+                    proof.publicValue,
+                    proof.publicOwner,
+                    proof.blindingFactors,
+                ]);
+                proof.challenge = proof.challengeHash.redKeccak();
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
+
+            it('should fail if blindingFactors NOT integrated into challenge variable', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                // Sixth element should have been the blindingFactors
+                proof.challengeHash = new Keccak();
+                proof.constructChallengeRecurse([
+                    proof.sender,
+                    proof.publicInteger,
+                    proof.publicValue,
+                    proof.publicOwner,
+                    proof.notes,
+                ]);
+                proof.challenge = proof.challengeHash.redKeccak();
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
+
+            it('should fail if points are NOT on the curve', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultGreaterThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const zeroPublicRangeProof = await mockZeroPublicRangeProof();
+                proof.data = zeroPublicRangeProof.data;
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
         });
     });
 
-    describe('Failure states', () => {
-        it('should fail if notes do NOT balance', async () => {
-            const originalNoteValue = 50;
-            const utilityNoteValue = 41;
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getNotes(
-                originalNoteValue,
-                utilityNoteValue,
-            );
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
+    describe('Less than tests', () => {
+        describe('Success states', () => {
+            it('should validate a less than proof', async () => {
+                const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultLessThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const data = proof.encodeABI();
+                const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS, { from: sender });
+                expect(result).to.equal(proof.eth.outputs);
+            });
+
+            it('should succeed for originalValue = publicInteger, when making a less than or equal to', async () => {
+                const isGreaterOrEqual = false;
+                const originalNoteValue = 20;
+                const utilityNoteValue = 40;
+                const publicInteger = 20;
+                const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const data = proof.encodeABI();
+                const result = await publicRangeValidator.validatePublicRange(data, sender, bn128.CRS, { from: sender });
+                expect(result).to.equal(proof.eth.outputs);
+            });
         });
 
-        it('should fail when note value is less than public integer', async () => {
-            const originalNoteValue = 9;
-            const utilityNoteValue = 0;
-            const publicInteger = 10;
-            const { originalNote, utilityNote, isGreaterOrEqual } = await getNotes(originalNoteValue, utilityNoteValue);
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
-        });
+        describe('Failure states', () => {
+            it('should fail for an unbalanced less than proof', async () => {
+                const isGreaterOrEqual = false;
+                const originalNoteValue = 20;
+                const utilityNoteValue = 0;
+                const publicInteger = 20;
+                const { originalNote, utilityNote } = await getNotes(originalNoteValue, utilityNoteValue);
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
 
-        it('should fail for random proof data', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            proof.data = [];
-            for (let i = 0; i < 2; i += 1) {
-                proof.data[i] = [];
-                for (let j = 0; j < 6; j += 1) {
-                    proof.data[i][j] = randomHex(32);
-                }
-            }
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
-        });
-
-        it('should fail for fake challenge', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            proof.challenge = new BN('0');
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
-        });
-
-        it('should fail if scalars are NOT mod(GROUP_MODULUS)', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            const kBar = new BN(proof.data[0][0].slice(2), 16);
-            const notModRKBar = `0x${kBar.add(bn128.groupModulus).toString(16)}`;
-            proof.data[0][0] = notModRKBar;
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
-        });
-
-        it('should fail if blinding factor resolves to point at infinity', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            proof.data[0][0] = padLeft('0x05', 64);
-            proof.data[0][1] = padLeft('0x05', 64);
-            proof.data[0][2] = `0x${bn128.H_X.toString(16)}`;
-            proof.data[0][3] = `0x${bn128.H_Y.toString(16)}`;
-            proof.data[0][4] = `0x${bn128.H_X.toString(16)}`;
-            proof.data[0][5] = `0x${bn128.H_Y.toString(16)}`;
-            proof.challenge = new BN('0a', 16);
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
-        });
-
-        it('should fail if scalars are zero', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            const zeroScalar = padLeft('0x00', 64);
-            proof.data[0][0] = zeroScalar;
-            proof.data[0][1] = zeroScalar;
-            proof.data[1][0] = zeroScalar;
-            proof.data[1][1] = zeroScalar;
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
-        });
-
-        it('should fail for incorrect H_X, H_Y in CRS', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            const malformedHx = bn128.H_X.add(new BN(1));
-            const malformedHy = bn128.H_Y.add(new BN(1));
-            const malformedCRS = [`0x${malformedHx.toString(16)}`, `0x${malformedHy.toString(16)}`, ...bn128.t2];
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, malformedCRS),
-                truffleAssert.ErrorType.REVERT,
-            );
-        });
-
-        it('should fail if provided 0 notes', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            proof.data = [];
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
-        });
-
-        it('should fail if sender NOT integrated into challenge variable', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            // First element should have been the sender
-            proof.challengeHash = new Keccak();
-            proof.constructChallengeRecurse([
-                proof.publicInteger,
-                proof.publicValue,
-                proof.publicOwner,
-                proof.notes,
-                proof.blindingFactors,
-            ]);
-            proof.challenge = proof.challengeHash.redKeccak();
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
-        });
-
-        it('should fail if publicInteger NOT integrated into challenge variable', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            // Second element should have been the publicInteger
-            proof.challengeHash = new Keccak();
-            proof.constructChallengeRecurse([
-                proof.sender,
-                proof.publicValue,
-                proof.publicOwner,
-                proof.notes,
-                proof.blindingFactors,
-            ]);
-            proof.challenge = proof.challengeHash.redKeccak();
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
-        });
-
-        it('should fail if publicValue NOT integrated into challenge variable', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            // Third element should have been the publicValue
-            proof.challengeHash = new Keccak();
-            proof.constructChallengeRecurse([
-                proof.sender,
-                proof.publicInteger,
-                proof.publicOwner,
-                proof.notes,
-                proof.blindingFactors,
-            ]);
-            proof.challenge = proof.challengeHash.redKeccak();
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
-        });
-
-        it('should fail if publicOwner NOT integrated into challenge variable', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            // Fourth element should have been the publicOwner
-            proof.challengeHash = new Keccak();
-            proof.constructChallengeRecurse([
-                proof.sender,
-                proof.publicInteger,
-                proof.publicValue,
-                proof.notes,
-                proof.blindingFactors,
-            ]);
-            proof.challenge = proof.challengeHash.redKeccak();
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
-        });
-
-        it('should fail if notes NOT integrated into challenge variable', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            // Fifth element should have been the notes
-            proof.challengeHash = new Keccak();
-            proof.constructChallengeRecurse([
-                proof.sender,
-                proof.publicInteger,
-                proof.publicValue,
-                proof.publicOwner,
-                proof.blindingFactors,
-            ]);
-            proof.challenge = proof.challengeHash.redKeccak();
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
-        });
-
-        it('should fail if blindingFactors NOT integrated into challenge variable', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            // Sixth element should have been the blindingFactors
-            proof.challengeHash = new Keccak();
-            proof.constructChallengeRecurse([
-                proof.sender,
-                proof.publicInteger,
-                proof.publicValue,
-                proof.publicOwner,
-                proof.notes,
-            ]);
-            proof.challenge = proof.challengeHash.redKeccak();
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
-        });
-
-        it.only('should fail if points are NOT on the curve', async () => {
-            const { originalNote, utilityNote, publicInteger, isGreaterOrEqual } = await getDefaultNotes();
-            const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
-            const zeroPublicRangeProof = await mockZeroPublicRangeProof();
-            proof.data = zeroPublicRangeProof.data;
-            const data = proof.encodeABI();
-            await truffleAssert.reverts(
-                publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
-                truffleAssert.ErrorType.REVERT,
-            );
+            it('should fail for a less than proof, when a greater than proof is specified', async () => {
+                const isGreaterOrEqual = true;
+                const { originalNote, utilityNote, publicInteger } = await getDefaultLessThanNotes();
+                const proof = new PublicRangeProof(originalNote, publicInteger, sender, isGreaterOrEqual, utilityNote);
+                const data = proof.encodeABI();
+                await truffleAssert.reverts(
+                    publicRangeValidator.validatePublicRange(data, sender, bn128.CRS),
+                    truffleAssert.ErrorType.REVERT,
+                );
+            });
         });
     });
 });

--- a/packages/protocol/test/helpers/proof.js
+++ b/packages/protocol/test/helpers/proof.js
@@ -87,6 +87,28 @@ const mockZeroPrivateRangeProof = () => {
     return zeroProof;
 };
 
+const mockZeroPublicRangeProof = () => {
+    const zeroProof = mockZeroProof();
+    const publicValue = padLeft('00', 64);
+    const publicComparison = padLeft('00', 64);
+    const challengeArray = [
+        zeroProof.sender,
+        publicComparison,
+        publicValue,
+        zeroProof.publicOwner,
+        ...zeroNote.slice(2),
+        ...zeroBlindingFactors,
+    ];
+    const challengeHash = keccak256(`0x${challengeArray.join('')}`);
+
+    zeroProof.challenge = new BN(challengeHash.slice(2), 16).umod(bn128.curve.n);
+    zeroProof.challengeHex = `0x${zeroProof.challenge.toString(16)}`;
+    zeroProof.data = Array(4).fill(zeroNote.map((element) => `0x${element}`));
+    zeroProof.publicValue = publicValue;
+    zeroProof.type = ProofType.PUBLIC_RANGE.name;
+    return zeroProof;
+};
+
 const mockZeroSwapProof = () => {
     const zeroProof = mockZeroProof();
     const challengeArray = [zeroProof.sender, ...zeroNote.slice(2), ...zeroBlindingFactors];
@@ -105,5 +127,6 @@ module.exports = {
     mockZeroJoinSplitFluidProof,
     mockZeroPrivateRangeProof,
     mockZeroProof,
+    mockZeroPublicRangeProof,
     mockZeroSwapProof,
 };


### PR DESCRIPTION
**This PR is similar to a previous PR for a publicRange proof that was opened and partly reviewed (https://github.com/AztecProtocol/AZTEC/pull/89). This PR largely migrates the old public range proof to the style of the recently refactored codebase**

## Summary
In many use cases, it is important to be able to prove that a confidential digital asset has a value greater than or less than a public integer. This has to be performed in zero-knowledge - that is the value of the original confidential digital asset is never revealed. We call this proof a public range proof.

This PR implements such a proof - providing the Javascript proof construction code and the smart contract proof validator.

<!--- Describe your changes in detail -->
## Description
The proof construction code can be found in `aztec.js` in the `proof` module. This constructs the proof that an input note is greater or less than a `publicInteger` that is also supplied. 

The smart contract validator and abi encoder can be found in the `protocol` package, under `contracts/ACE/validators/publicRange`.

## Testing instructions
`yarn test`

## Types of changes
**New feature (non-breaking change which adds functionality**
This PR implements a new feature - a publicRange proof. There are no breaking changes.

**Test corrections**
Some proof validation tests have been corrected. Across all proofs, false positives were being returned for the failure tests checking failure when certain variables were not mixed into the challenge hash. This was due to the challenge hash being hashed > once.

## Notes
The JavaScript part of this PR is similar to a previous PR that was reviewed. The proof validation aspect of this PR is also similar, but has not been reviewed before. 

## Future work/next steps
The `utilityNote` should be abstracted away from the proof construction interface, it is currently exposed. It serves as a 'behind the scenses' helper note used to construct a proof statement. 

Abstracting the `utilityNote` away such that it would be constructed inside the proof, would naively require making the constructor asynchronous - will consider the best way to avoid this. 


