### PR TITLE
Refactor EIP712 to be consistent with MetaMask

### DIFF
--- a/packages/aztec.js/package.json
+++ b/packages/aztec.js/package.json
@@ -33,6 +33,7 @@
     "eslint-config-prettier": "^4.1.0",
     "eslint-loader": "^2.1.2",
     "eslint-plugin-import": "^2.16.0",
+    "eth-sig-util": "^2.3.0",
     "fixpack": "^2.3.1",
     "jsdoc": "^3.5.5",
     "mocha": "^6.0.2",

--- a/packages/aztec.js/src/proof/joinSplit/index.js
+++ b/packages/aztec.js/src/proof/joinSplit/index.js
@@ -145,7 +145,7 @@ class JoinSplitProof extends Proof {
     /**
      * Construct EIP712 signatures, giving permission for the input notes to be spent
      * @param {string} verifyingContract Ethereum address of the ZkAsset contract, from which confidentialTransfer() is
-     * called 
+     * called
      * @param {string[]} inputNoteOwners Ethereum accounts of input note owners
      * @returns {string} array of signatures
      */

--- a/packages/aztec.js/src/proof/joinSplit/index.js
+++ b/packages/aztec.js/src/proof/joinSplit/index.js
@@ -150,16 +150,13 @@ class JoinSplitProof extends Proof {
      * @returns {string} array of signatures
      */
     constructSignatures(verifyingContract, inputNoteOwners) {
-        const signaturesArray = inputNoteOwners.map((inputNoteOwner, index) => {
-            return signer.signNotesForConfidentialTransfer(
-                verifyingContract,
-                inputNoteOwner,
-                this.inputNotes[index].noteHash,
-                this.challengeHex,
-                this.sender,
-            );
-        });
-        return `0x${signaturesArray.join('')}`;
+        return signer.signMultipleNotesForConfidentialTransfer(
+            verifyingContract,
+            inputNoteOwners,
+            this.inputNotes,
+            this.challengeHex,
+            this.sender,
+        );
     }
 
     /**

--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -5,10 +5,10 @@
  * @module signer
  */
 
-const { constants } = require('@aztec/dev-utils');
+const { constants, proofs } = require('@aztec/dev-utils');
 const secp256k1 = require('@aztec/secp256k1');
 const typedData = require('@aztec/typed-data');
-const { randomHex } = require('web3-utils');
+const { randomHex, padRight } = require('web3-utils');
 
 const signer = {};
 
@@ -40,19 +40,21 @@ signer.generateZKAssetDomainParams = (verifyingContract) => {
 };
 
 /**
- * Create an EIP712 ECDSA signature over an AZTEC note, for a ZkAsset.sol domain
+ * Create an EIP712 ECDSA signature over an AZTEC note, suited for the confidentialApprove() method of a 
+ * ZkAsset. The ZkAsset.confidentialApprove() method must be called when granting note spending permission
+ * to a third party and is required in order for ZkAsset.confidentialTransferFrom() to be successful.
  *
- * This is expected to be the default signNote() function. However for use cases, such as
+ * This is expected to be the most commonly used note signing() function. However for use cases, such as
  * testing, where ACE domain params are required then the signNoteACEDomain() function is
  * available.
- * @method signNote
+ * @method signNoteForConfidentialApprove
  * @param {string} verifyingContract address of target contract
  * @param {string} noteHash noteHash of the note being signed
  * @param {string} spender address of the note spender
  * @param {string} privateKey the private key of message signer
- * @returns {string} ECDSA signature parameters [r, s, v]
+ * @returns {string} ECDSA signature parameters [r, s, v], formatted as 32-byte wide hex-strings
  */
-signer.signNote = (verifyingContract, noteHash, spender, privateKey) => {
+signer.signNoteForConfidentialApprove = (verifyingContract, noteHash, spender, privateKey) => {
     const domain = signer.generateZKAssetDomainParams(verifyingContract);
     const schema = constants.eip712.NOTE_SIGNATURE;
     const status = true;
@@ -62,7 +64,43 @@ signer.signNote = (verifyingContract, noteHash, spender, privateKey) => {
         status,
     };
     const { signature } = signer.signTypedData(domain, schema, message, privateKey);
-    return signature[1] + signature[2].slice(2) + signature[0].slice(-2);
+    const r = signature[1];
+    const s = signature[2].slice(2);
+    const v = signature[0].slice(-2);
+    return r + s + v;
+};
+
+/**
+ * Create an EIP712 ECDSA signature over an AZTEC note, to be used to give permission for
+ * note expenditure during a zkAsset confidentialTransfer() method call
+ *
+ * @method signNoteForConfidentialTransfer
+ * @param {string} verifyingContract address of target contract
+ * @param {string} noteOwnerAccount Ethereum account (privateKey, publicKey and address) of owner of the note
+ * being signed
+ * @param {string} noteHash hash of the note being signed
+ * @param {string} challenge hexadecimal representation of the challenge variable
+ * @param {string} sender address of the transaction sender
+ * @returns {string} ECDSA signature parameters [r, s, v] 
+ */
+signer.signNotesForConfidentialTransfer = (verifyingContract, noteOwnerAccount, noteHash, challenge, sender) => {
+    const domain = signer.generateZKAssetDomainParams(verifyingContract);
+    const schema = constants.eip712.JOIN_SPLIT_SIGNATURE;
+    const message = {
+        proof: proofs.JOIN_SPLIT_PROOF,
+        noteHash,
+        challenge,
+        sender,
+    };
+
+    const { privateKey } = noteOwnerAccount;
+    const { signature } = signer.signTypedData(domain, schema, message, privateKey);
+
+    const r = signature[1].slice(2);
+    const s = signature[2].slice(2);
+    const v = padRight(signature[0].slice(-2), 64);
+
+    return r + s + v;
 };
 
 /**

--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -50,7 +50,7 @@ signer.generateZKAssetDomainParams = (verifyingContract) => {
  * @param {string} noteHash noteHash of the note being signed
  * @param {string} spender address of the note spender
  * @param {string} privateKey the private key of message signer
- * @returns {string} ECDSA signature parameters [v, r, s], formatted as 32-byte wide hex-strings
+ * @returns {string} ECDSA signature parameters [r, s, v]
  */
 signer.signNote = (verifyingContract, noteHash, spender, privateKey) => {
     const domain = signer.generateZKAssetDomainParams(verifyingContract);
@@ -62,7 +62,7 @@ signer.signNote = (verifyingContract, noteHash, spender, privateKey) => {
         status,
     };
     const { signature } = signer.signTypedData(domain, schema, message, privateKey);
-    return signature[0] + signature[1].slice(2) + signature[2].slice(2);
+    return signature[1] + signature[2].slice(2) + signature[0].slice(-2);
 };
 
 /**

--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -40,7 +40,7 @@ signer.generateZKAssetDomainParams = (verifyingContract) => {
 };
 
 /**
- * Create an EIP712 ECDSA signature over an AZTEC note, suited for the confidentialApprove() method of a 
+ * Create an EIP712 ECDSA signature over an AZTEC note, suited for the confidentialApprove() method of a
  * ZkAsset. The ZkAsset.confidentialApprove() method must be called when granting note spending permission
  * to a third party and is required in order for ZkAsset.confidentialTransferFrom() to be successful.
  *
@@ -81,7 +81,7 @@ signer.signNoteForConfidentialApprove = (verifyingContract, noteHash, spender, p
  * @param {string} noteHash hash of the note being signed
  * @param {string} challenge hexadecimal representation of the challenge variable
  * @param {string} sender address of the transaction sender
- * @returns {string} ECDSA signature parameters [r, s, v] 
+ * @returns {string} ECDSA signature parameters [r, s, v]
  */
 signer.signNotesForConfidentialTransfer = (verifyingContract, noteOwnerAccount, noteHash, challenge, sender) => {
     const domain = signer.generateZKAssetDomainParams(verifyingContract);

--- a/packages/aztec.js/test/signer/index.js
+++ b/packages/aztec.js/test/signer/index.js
@@ -105,29 +105,39 @@ describe('Signer', () => {
             expect(publicKeyRecover).to.equal(publicKey.slice(4));
         });
 
-        it('signNote() should produce a well formed `v` ECDSA parameter', async () => {
-            const {publicKey, privateKey} = secp256k1.generateAccount();
+        it('signNoteForConfidentialApprove() should produce a well formed `v` ECDSA parameter', async () => {
+            const { publicKey, privateKey } = secp256k1.generateAccount();
             const spender = randomHex(20);
             const verifyingContract = randomHex(20);
             const testNoteValue = 10;
             const testNote = await note.create(publicKey, testNoteValue);
 
-            const signature = signer.signNote(verifyingContract, testNote.noteHash, spender, privateKey);
+            const signature = signer.signNoteForConfidentialApprove(
+                verifyingContract,
+                testNote.noteHash,
+                spender,
+                privateKey,
+            );
             const v = parseInt(signature.slice(130, 132), 16);
             expect(v).to.be.oneOf([27, 28]);
         });
 
         it('should recover publicKey from signature params', async () => {
-            const {publicKey, privateKey} = secp256k1.generateAccount();
+            const { publicKey, privateKey } = secp256k1.generateAccount();
             const spender = randomHex(20);
             const verifyingContract = randomHex(20);
             const testNoteValue = 10;
             const testNote = await note.create(publicKey, testNoteValue);
 
-            const signature = signer.signNote(verifyingContract, testNote.noteHash, spender, privateKey);
+            const signature = signer.signNoteForConfidentialApprove(
+                verifyingContract,
+                testNote.noteHash,
+                spender,
+                privateKey,
+            );
 
             const r = Buffer.from(signature.slice(2, 66), 'hex');
-            const s = Buffer.from(signature.slice(66, 130), 'hex')
+            const s = Buffer.from(signature.slice(66, 130), 'hex');
             const v = parseInt(signature.slice(130, 132), 16);
 
             const domain = signer.generateZKAssetDomainParams(verifyingContract);
@@ -144,7 +154,7 @@ describe('Signer', () => {
             expect(publicKeyRecover).to.equal(publicKey.slice(4));
         });
 
-        it('signNote() should produce same signature as MetaMask signing function', async () => {
+        it('signNoteForConfidentialApprove() should produce same signature as MetaMask signing function', async () => {
             const aztecAccount = secp256k1.generateAccount();
             const spender = randomHex(20);
             const verifyingContract = randomHex(20);
@@ -155,7 +165,8 @@ describe('Signer', () => {
                 domain: {
                     name: 'ZK_ASSET',
                     version: '1',
-                    verifyingContract },
+                    verifyingContract,
+                },
                 types: {
                     NoteSignature: [
                         { name: 'noteHash', type: 'bytes32' },
@@ -176,7 +187,12 @@ describe('Signer', () => {
                 },
             };
 
-            const aztecSignature = signer.signNote(verifyingContract, testNote.noteHash, spender, aztecAccount.privateKey);
+            const aztecSignature = signer.signNoteForConfidentialApprove(
+                verifyingContract,
+                testNote.noteHash,
+                spender,
+                aztecAccount.privateKey,
+            );
             const metaMaskSignature = ethSigUtil.signTypedData(Buffer.from(aztecAccount.privateKey.slice(2), 'hex'), {
                 data: metaMaskTypedData,
             });

--- a/packages/aztec.js/test/signer/index.js
+++ b/packages/aztec.js/test/signer/index.js
@@ -112,12 +112,7 @@ describe('Signer', () => {
             const testNoteValue = 10;
             const testNote = await note.create(publicKey, testNoteValue);
 
-            const signature = signer.signNoteForConfidentialApprove(
-                verifyingContract,
-                testNote.noteHash,
-                spender,
-                privateKey,
-            );
+            const signature = signer.signNoteForConfidentialApprove(verifyingContract, testNote.noteHash, spender, privateKey);
             const v = parseInt(signature.slice(130, 132), 16);
             expect(v).to.be.oneOf([27, 28]);
         });
@@ -129,12 +124,7 @@ describe('Signer', () => {
             const testNoteValue = 10;
             const testNote = await note.create(publicKey, testNoteValue);
 
-            const signature = signer.signNoteForConfidentialApprove(
-                verifyingContract,
-                testNote.noteHash,
-                spender,
-                privateKey,
-            );
+            const signature = signer.signNoteForConfidentialApprove(verifyingContract, testNote.noteHash, spender, privateKey);
 
             const r = Buffer.from(signature.slice(2, 66), 'hex');
             const s = Buffer.from(signature.slice(66, 130), 'hex');
@@ -193,6 +183,8 @@ describe('Signer', () => {
                 spender,
                 aztecAccount.privateKey,
             );
+
+            // eth-sig-util is the MetaMask signing package
             const metaMaskSignature = ethSigUtil.signTypedData(Buffer.from(aztecAccount.privateKey.slice(2), 'hex'), {
                 data: metaMaskTypedData,
             });

--- a/packages/aztec.js/test/signer/index.js
+++ b/packages/aztec.js/test/signer/index.js
@@ -4,9 +4,11 @@ const secp256k1 = require('@aztec/secp256k1');
 const typedData = require('@aztec/typed-data');
 const BN = require('bn.js');
 const { expect } = require('chai');
+const ethSigUtil = require('eth-sig-util');
 const ethUtil = require('ethereumjs-util');
 const { keccak256, padLeft, randomHex } = require('web3-utils');
 
+const note = require('../../src/note');
 const signer = require('../../src/signer');
 
 describe('Signer', () => {
@@ -101,6 +103,84 @@ describe('Signer', () => {
 
             const publicKeyRecover = ethUtil.ecrecover(messageHash, v, r, s).toString('hex');
             expect(publicKeyRecover).to.equal(publicKey.slice(4));
+        });
+
+        it('signNote() should produce a well formed `v` ECDSA parameter', async () => {
+            const {publicKey, privateKey} = secp256k1.generateAccount();
+            const spender = randomHex(20);
+            const verifyingContract = randomHex(20);
+            const testNoteValue = 10;
+            const testNote = await note.create(publicKey, testNoteValue);
+
+            const signature = signer.signNote(verifyingContract, testNote.noteHash, spender, privateKey);
+            const v = parseInt(signature.slice(130, 132), 16);
+            expect(v).to.be.oneOf([27, 28]);
+        });
+
+        it('should recover publicKey from signature params', async () => {
+            const {publicKey, privateKey} = secp256k1.generateAccount();
+            const spender = randomHex(20);
+            const verifyingContract = randomHex(20);
+            const testNoteValue = 10;
+            const testNote = await note.create(publicKey, testNoteValue);
+
+            const signature = signer.signNote(verifyingContract, testNote.noteHash, spender, privateKey);
+
+            const r = Buffer.from(signature.slice(2, 66), 'hex');
+            const s = Buffer.from(signature.slice(66, 130), 'hex')
+            const v = parseInt(signature.slice(130, 132), 16);
+
+            const domain = signer.generateZKAssetDomainParams(verifyingContract);
+            const schema = constants.eip712.NOTE_SIGNATURE;
+            const message = {
+                noteHash: testNote.noteHash,
+                spender,
+                status: true,
+            };
+            const { encodedTypedData } = signer.signTypedData(domain, schema, message, privateKey);
+            const messageHash = Buffer.from(encodedTypedData.slice(2), 'hex');
+
+            const publicKeyRecover = ethUtil.ecrecover(messageHash, v, r, s).toString('hex');
+            expect(publicKeyRecover).to.equal(publicKey.slice(4));
+        });
+
+        it('signNote() should produce same signature as MetaMask signing function', async () => {
+            const aztecAccount = secp256k1.generateAccount();
+            const spender = randomHex(20);
+            const verifyingContract = randomHex(20);
+            const testNoteValue = 10;
+            const testNote = await note.create(aztecAccount.publicKey, testNoteValue);
+
+            const metaMaskTypedData = {
+                domain: {
+                    name: 'ZK_ASSET',
+                    version: '1',
+                    verifyingContract },
+                types: {
+                    NoteSignature: [
+                        { name: 'noteHash', type: 'bytes32' },
+                        { name: 'spender', type: 'address' },
+                        { name: 'status', type: 'bool' },
+                    ],
+                    EIP712Domain: [
+                        { name: 'name', type: 'string' },
+                        { name: 'version', type: 'string' },
+                        { name: 'verifyingContract', type: 'address' },
+                    ],
+                },
+                primaryType: 'NoteSignature',
+                message: {
+                    noteHash: testNote.noteHash,
+                    spender,
+                    status: true,
+                },
+            };
+
+            const aztecSignature = signer.signNote(verifyingContract, testNote.noteHash, spender, aztecAccount.privateKey);
+            const metaMaskSignature = ethSigUtil.signTypedData(Buffer.from(aztecAccount.privateKey.slice(2), 'hex'), {
+                data: metaMaskTypedData,
+            });
+            expect(aztecSignature).to.equal(metaMaskSignature);
         });
     });
 });

--- a/packages/protocol/contracts/libs/LibEIP712.sol
+++ b/packages/protocol/contracts/libs/LibEIP712.sol
@@ -39,7 +39,7 @@ contract LibEIP712 {
     }
 
     /// @dev Calculates EIP712 encoding for a hash struct in this EIP712 Domain.
-    /// @param _hashStruct The EIP712 hash struct.
+    /// @param _hashStruct The EIP712 hash struct.  
     /// @return EIP712 hash applied to this EIP712 Domain.
     function hashEIP712Message(bytes32 _hashStruct)
         internal
@@ -82,25 +82,48 @@ contract LibEIP712 {
             // Here's a little trick we can pull. We expect `_signature` to be a byte array, of length 0x60, with
             // 'v', 'r' and 's' located linearly in memory. Preceeding this is the length parameter of `_signature`.
             // We *replace* the length param with the signature msg to get a memory block formatted for the precompile
-
             // load length as a temporary variable
+
             let byteLength := mload(_signature)
 
             // store the signature message
             mstore(_signature, _message)
 
             // load 'v' - we need it for a condition check
-            let v := mload(add(_signature, 0x20))
+            let v := mload(add(_signature, 0x60))
+            v := shr(248, v) // bitshifting, to resemble padLeft
 
+            /**
+            * Original memory map for input to precompile
+            *
+            * _signature : _signature + 0x20            message 
+            * _signature + 0x20 : _signature + 0x40     r
+            * _signature + 0x40 : _signature + 0x60     s
+            * _signature + 0x60 : _signature + 0x80     v
+
+            * Desired memory map for input to precompile
+            *
+            * _signature : _signature + 0x20            message 
+            * _signature + 0x20 : _signature + 0x40     v
+            * _signature + 0x40 : _signature + 0x60     r
+            * _signature + 0x60 : _signature + 0x80     s
+            */
+
+            // move s to v position
+            mstore(add(_signature, 0x60), mload(add(_signature, 0x40)))
+            // move r to s position
+            mstore(add(_signature, 0x40), mload(add(_signature, 0x20)))
+            // move v to r position
+            mstore(add(_signature, 0x20), v)
             result := and(
                 and(
-                    // validate signature length == 0x60 bytes
-                    eq(byteLength, 0x60),
+                    // validate signature length == 0x41 bytes
+                    or(eq(byteLength, 0x41), eq(byteLength, 0x60)),
                     // validate v == 27 or v == 28
                     or(eq(v, 27), eq(v, 28))
                 ),
                 // validate call to precompile succeeds
-                staticcall(gas, 0x01, _signature, 0x80, _signature, 0x20)
+                staticcall(gas, 0x01, _signature, 0x80, _signature, 0x20) 
             )
             // save the _signer only if the first word in _signature is not `_message` anymore
             switch eq(_message, mload(_signature))

--- a/packages/protocol/contracts/libs/LibEIP712.sol
+++ b/packages/protocol/contracts/libs/LibEIP712.sol
@@ -117,7 +117,9 @@ contract LibEIP712 {
             mstore(add(_signature, 0x20), v)
             result := and(
                 and(
-                    // validate signature length == 0x41 bytes
+                    // validate signature length == 0x41 or 0x60 bytes. 
+                    // will be 0x41 if one signature was provided, 0x60 if multiple signatures 
+                    // have been provided - due to the relevant signature creation functions
                     or(eq(byteLength, 0x41), eq(byteLength, 0x60)),
                     // validate v == 27 or v == 28
                     or(eq(v, 27), eq(v, 28))

--- a/packages/protocol/test/ERC1724/ZkAsset.js
+++ b/packages/protocol/test/ERC1724/ZkAsset.js
@@ -96,7 +96,7 @@ contract('ZkAsset', (accounts) => {
             expect(result.toNumber()).to.equal(scalingFactor.toNumber());
         });
 
-        it('should update a note registry with output notes', async () => {
+        it.only ('should update a note registry with output notes', async () => {
             const zkAsset = await ZkAsset.new(ace.address, erc20.address, scalingFactor);
             const {
                 depositInputNotes,
@@ -313,6 +313,7 @@ contract('ZkAsset', (accounts) => {
             );
             const depositData = depositProof.encodeABI(zkAsset.address);
             const depositSignatures = depositProof.constructSignatures(zkAsset.address, depositInputOwnerAccounts);
+
 
             await ace.publicApprove(zkAsset.address, depositProof.hash, depositPublicValue, { from: accounts[0] });
             await zkAsset.confidentialTransfer(depositData, depositSignatures);

--- a/packages/protocol/test/ERC1724/ZkAsset.js
+++ b/packages/protocol/test/ERC1724/ZkAsset.js
@@ -316,7 +316,6 @@ contract('ZkAsset', (accounts) => {
 
             await ace.publicApprove(zkAsset.address, depositProof.hash, depositPublicValue, { from: accounts[0] });
             await zkAsset.confidentialTransfer(depositData, depositSignatures);
-
             const withdrawalProof = new JoinSplitProof(
                 transferInputNotes,
                 transferOutputNotes,
@@ -327,7 +326,6 @@ contract('ZkAsset', (accounts) => {
 
             const transferData = withdrawalProof.encodeABI(zkAsset.address);
             const transferSignatures = withdrawalProof.constructSignatures(zkAsset.address, transferInputOwnerAccounts);
-
             const { receipt } = await zkAsset.confidentialTransfer(transferData, transferSignatures);
             expect(receipt.status).to.equal(true);
         });

--- a/packages/protocol/test/ERC1724/ZkAsset.js
+++ b/packages/protocol/test/ERC1724/ZkAsset.js
@@ -96,7 +96,7 @@ contract('ZkAsset', (accounts) => {
             expect(result.toNumber()).to.equal(scalingFactor.toNumber());
         });
 
-        it.only ('should update a note registry with output notes', async () => {
+        it('should update a note registry with output notes', async () => {
             const zkAsset = await ZkAsset.new(ace.address, erc20.address, scalingFactor);
             const {
                 depositInputNotes,
@@ -313,7 +313,6 @@ contract('ZkAsset', (accounts) => {
             );
             const depositData = depositProof.encodeABI(zkAsset.address);
             const depositSignatures = depositProof.constructSignatures(zkAsset.address, depositInputOwnerAccounts);
-
 
             await ace.publicApprove(zkAsset.address, depositProof.hash, depositPublicValue, { from: accounts[0] });
             await zkAsset.confidentialTransfer(depositData, depositSignatures);

--- a/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
@@ -43,7 +43,7 @@ const getCustomMintNotes = async (newMintCounterValue, mintedNoteValues) => {
 const confidentialApprove = async (zkAssetAdjustable, delegateAddress, indexes, notes, ownerAccount) => {
     await Promise.all(
         indexes.map((i) => {
-            const signature = signer.signNote(
+            const signature = signer.signNoteForConfidentialApprove(
                 zkAssetAdjustable.address,
                 notes[i].noteHash,
                 delegateAddress,

--- a/packages/protocol/test/ERC1724/ZkAssetMintable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetMintable.js
@@ -43,7 +43,7 @@ const getCustomMintNotes = async (newMintCounterValue, mintedNoteValues) => {
 const confidentialApprove = async (zkAssetMintable, delegateAddress, indexes, notes, ownerAccount) => {
     await Promise.all(
         indexes.map((i) => {
-            const signature = signer.signNote(
+            const signature = signer.signNoteForConfidentialApprove(
                 zkAssetMintable.address,
                 notes[i].noteHash,
                 delegateAddress,

--- a/packages/protocol/test/ERC1724/ZkAssetOwnable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetOwnable.js
@@ -33,7 +33,7 @@ contract('ZkAssetOwnable', (accounts) => {
     const confidentialApprove = async (indexes, notes, aztecAccounts) => {
         await Promise.all(
             indexes.map((i) => {
-                const signature = signer.signNote(
+                const signature = signer.signNoteForConfidentialApprove(
                     zkAssetOwnable.address,
                     notes[i].noteHash,
                     zkAssetOwnableTest.address,
@@ -246,7 +246,7 @@ contract('ZkAssetOwnable', (accounts) => {
             });
             await zkAssetOwnable.confidentialTransfer(depositData, depositSignatures, { from: accounts[0] });
 
-            const signature = signer.signNote(
+            const signature = signer.signNoteForConfidentialApprove(
                 zkAssetOwnable.address,
                 notes[0].noteHash,
                 zkAssetOwnableTest.address,
@@ -303,7 +303,7 @@ contract('ZkAssetOwnable', (accounts) => {
 
             await zkAssetOwnable.confidentialTransfer(transferData, transferSignatures);
 
-            const signature = signer.signNote(
+            const signature = signer.signNoteForConfidentialApprove(
                 zkAssetOwnable.address,
                 transferInputNotes[0].noteHash,
                 zkAssetOwnableTest.address,

--- a/packages/protocol/test/libs/LibEIP712.js
+++ b/packages/protocol/test/libs/LibEIP712.js
@@ -94,7 +94,7 @@ contract('LibEIP712', (accounts) => {
             const seg1 = signature[1].slice(2);
             const v1 = padLeft('0', seg1.length);
             expect(v1).not.to.equal(seg1);
-            const invalidSignature1 = signature[0] + v1 + signature[2].slice(2);
+            const invalidSignature1 = `0x${signature[0] + v1 + signature[2].slice(2)}`;
             await truffleAssert.reverts(
                 libEIP712._recoverSignature(encodedTypedData, invalidSignature1),
                 'signer address cannot be 0',
@@ -103,7 +103,7 @@ contract('LibEIP712', (accounts) => {
             const seg2 = signature[2].slice(2);
             const v2 = padLeft('0', seg2.length);
             expect(v2).not.to.equal(seg2);
-            const invalidSignature2 = signature[0] + signature[1].slice(2) + v2;
+            const invalidSignature2 = `0x${signature[0] + signature[1].slice(2) + v2}`;
             await truffleAssert.reverts(
                 libEIP712._recoverSignature(encodedTypedData, invalidSignature2),
                 'signer address cannot be 0',
@@ -118,10 +118,10 @@ contract('LibEIP712', (accounts) => {
                 aztecAccount.privateKey,
             );
 
-            const invalidSignature2 = signature[0] + signature[1].slice(2) + signature[2].slice(2) + '10';
+            const invalidSignature2 = `0x${signature[0] + signature[1].slice(2) + signature[2].slice(2) + '10'}`;
             await truffleAssert.reverts(
                 libEIP712._recoverSignature(encodedTypedData, invalidSignature2),
-                'signature recovery failed',
+                'signer address cannot be 0',
             );
         });
     });

--- a/packages/protocol/test/libs/LibEIP712.js
+++ b/packages/protocol/test/libs/LibEIP712.js
@@ -59,7 +59,7 @@ contract('LibEIP712', (accounts) => {
                 aztecAccount.address,
                 aztecAccount.privateKey,
             );
-            const concatenatedSignature =  signature[1] + signature[2].slice(2) + signature[0].slice(-2);
+            const concatenatedSignature = signature[1] + signature[2].slice(2) + signature[0].slice(-2);
             const result = await libEIP712._recoverSignature(encodedTypedData, concatenatedSignature);
             expect(result).to.equal(aztecAccount.address);
         });
@@ -77,7 +77,7 @@ contract('LibEIP712', (accounts) => {
             // see https://ethereum.stackexchange.com/questions/69328/how-to-get-0x0-from-ecrecover/69329#69329
             const r = signature[0];
             const s = signature[1].slice(2);
-            const v = '10'
+            const v = '10';
             const concatenatedSignature = r + s + v;
             await truffleAssert.reverts(
                 libEIP712._recoverSignature(encodedTypedData, concatenatedSignature),

--- a/packages/protocol/test/libs/LibEIP712.js
+++ b/packages/protocol/test/libs/LibEIP712.js
@@ -74,9 +74,9 @@ contract('LibEIP712', (accounts) => {
             );
 
             // see https://ethereum.stackexchange.com/questions/69328/how-to-get-0x0-from-ecrecover/69329#69329
-            
+
             // Replacing v with an incorrect value of 10
-            const incorrectSignature = signature.slice(0, 128) + '10'
+            const incorrectSignature = signature.slice(0, 128) + '10';
             await truffleAssert.reverts(
                 libEIP712._recoverSignature(encodedTypedData, incorrectSignature),
                 'signer address cannot be 0',

--- a/packages/protocol/test/libs/LibEIP712.js
+++ b/packages/protocol/test/libs/LibEIP712.js
@@ -59,8 +59,7 @@ contract('LibEIP712', (accounts) => {
                 aztecAccount.address,
                 aztecAccount.privateKey,
             );
-            const concatenatedSignature = signature[1] + signature[2].slice(2) + signature[0].slice(-2);
-            const result = await libEIP712._recoverSignature(encodedTypedData, concatenatedSignature);
+            const result = await libEIP712._recoverSignature(encodedTypedData, signature);
             expect(result).to.equal(aztecAccount.address);
         });
     });
@@ -75,12 +74,11 @@ contract('LibEIP712', (accounts) => {
             );
 
             // see https://ethereum.stackexchange.com/questions/69328/how-to-get-0x0-from-ecrecover/69329#69329
-            const r = signature[0];
-            const s = signature[1].slice(2);
-            const v = '10';
-            const concatenatedSignature = r + s + v;
+            
+            // Replacing v with an incorrect value of 10
+            const incorrectSignature = signature.slice(0, 128) + '10'
             await truffleAssert.reverts(
-                libEIP712._recoverSignature(encodedTypedData, concatenatedSignature),
+                libEIP712._recoverSignature(encodedTypedData, incorrectSignature),
                 'signer address cannot be 0',
             );
         });

--- a/packages/protocol/test/libs/LibEIP712.js
+++ b/packages/protocol/test/libs/LibEIP712.js
@@ -59,7 +59,7 @@ contract('LibEIP712', (accounts) => {
                 aztecAccount.address,
                 aztecAccount.privateKey,
             );
-            const concatenatedSignature = signature[0] + signature[1].slice(2) + signature[2].slice(2);
+            const concatenatedSignature =  signature[1] + signature[2].slice(2) + signature[0].slice(-2);
             const result = await libEIP712._recoverSignature(encodedTypedData, concatenatedSignature);
             expect(result).to.equal(aztecAccount.address);
         });
@@ -75,8 +75,10 @@ contract('LibEIP712', (accounts) => {
             );
 
             // see https://ethereum.stackexchange.com/questions/69328/how-to-get-0x0-from-ecrecover/69329#69329
-            const v = padLeft('0x10', 64);
-            const concatenatedSignature = v + signature[1].slice(2) + signature[2].slice(2);
+            const r = signature[0];
+            const s = signature[1].slice(2);
+            const v = '10'
+            const concatenatedSignature = r + s + v;
             await truffleAssert.reverts(
                 libEIP712._recoverSignature(encodedTypedData, concatenatedSignature),
                 'signer address cannot be 0',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6347,6 +6347,18 @@ eth-sig-util@^1.4.2:
     ethereumjs-abi "git+https://github.com/ethereumjs/ethereumjs-abi.git"
     ethereumjs-util "^5.1.1"
 
+eth-sig-util@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-2.3.0.tgz#c54a6ac8e8796f7e25f59cf436982a930e645231"
+  integrity sha512-ugD1AvaggvKaZDgnS19W5qOfepjGc7qHrt7TrAaL54gJw9SHvgIXJ3r2xOMW30RWJZNP+1GlTOy5oye7yXA4xA==
+  dependencies:
+    buffer "^5.2.1"
+    elliptic "^6.4.0"
+    ethereumjs-abi "0.6.5"
+    ethereumjs-util "^5.1.1"
+    tweetnacl "^1.0.0"
+    tweetnacl-util "^0.15.0"
+
 eth-tx-summary@^3.1.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/eth-tx-summary/-/eth-tx-summary-3.2.4.tgz#e10eb95eb57cdfe549bf29f97f1e4f1db679035c"


### PR DESCRIPTION
## Summary
This PR makes the AZTEC EIP712 implementation consistent with that of MetaMask. 

MetaMask uses the package `eth-sig-util` to perform signing, specifically using the function `signTypedData()` - https://github.com/MetaMask/eth-sig-util. This outputs an ECDSA signature, with the parameters being output in the order: `(r, s, v)`.

This order of parameters is different to the AZTEC signing functions, which output in order`(v, r, s)`. The EVM precompile that is then used to perform signature verification, ecrecover, expects params to be in order `(v, r, s)`. 

This PR updates the AZTEC signature verification contracts and signing functions, so that signatures generated with MetaMask (signing over AZTEC notes) can be verified by the AZTEC contracts.

<!--- Describe your changes in detail -->
## Detailed changes
The major changes relate to two packages: `aztec.js` and `protocol`.

**aztec.js**
- `signer` module: Where the note signing functions return ECDSA parameters, they have been adjusted to be in the order `(r, s, v)` rather than `(v, r, s)`
- `proof` module: the `joinSplit.constructSignatures()` code has been refactored and largely broken out into a seperate method that is now in the `signer` module

**protocol**
- `LibEIP712.sol` - `recoverSignature()` adapted to deal with params in `(r, s, v)` order and rearrange into correct form for ecrecover precompile
- `ZkAsset.sol` - `extractSignature()`adapted to deal with params in different order

## Testing instructions
`yarn test`

Various additional tests have been added

## Types of changes
**Breaking change**
There are a couple of breaking changes:
1) `signer.signNote()` has been renamed to `signer.signNoteForConfidentialApprove()` to better describe what this function should be used for and seperate it from the other signing functions
2) The ECDSA parameter output order for note signing functions in the `signer` module have been changed from `(v, r, s)` to `(r, s, v)` 

