### PR TITLE
Emit noteRegistry creation event in NoteRegistry.sol

### DIFF
--- a/packages/protocol/contracts/ACE/NoteRegistry.sol
+++ b/packages/protocol/contracts/ACE/NoteRegistry.sol
@@ -20,6 +20,16 @@ contract NoteRegistry is IAZTEC {
     using SafeMath for uint256;
     using ProofUtils for uint24;
 
+    // registry address is same as ACE address
+    event CreateNoteRegistry(
+        address registryOwner,
+        address registryAddress,
+        uint256 scalingFactor,
+        address linkedTokenAddress,
+        bool canAdjustSupply,
+        bool canConvert
+    );
+
     /**
     * Note struct. This is the data that we store when we log AZTEC notes inside a NoteRegistry
     *
@@ -126,6 +136,15 @@ contract NoteRegistry is IAZTEC {
             })
         });
         registries[msg.sender] = registry;
+
+        emit CreateNoteRegistry(
+            msg.sender,
+            address(this),
+            _scalingFactor,
+            _linkedTokenAddress,
+            _canAdjustSupply,
+            _canConvert
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
Removed the event creation in `ZkAsset.sol` to signal a ZkAsset creation, and instead emitting an event in `NoteRegistry.sol` whenever a note registry is created. 

This is done to aid the implementation of the graph. It is still sufficient to signal creation of a ZkAsset, because a noteRegistry is automatically created in the constructor everytime a ZkAsset is initialised. 

Added a test in `NoteRegistry.js` to check the emitted event is as expected.

## Files affected:
All in the `protocol` package:
- `ZkAsset.sol`
- `NoteRegistry.sol`
- `NoteRegistry.js`