### PR TITLE
fix(protocol): wrong if statement in recoverSignature

### DIFF
--- a/packages/protocol/contracts/libs/LibEIP712.sol
+++ b/packages/protocol/contracts/libs/LibEIP712.sol
@@ -110,7 +110,7 @@ contract LibEIP712 {
             mstore(_signature, byteLength) // and put the byte length back where it belongs
         }
         // wrap Failure States in a single if test, so that happy path only has 1 conditional jump
-        if (!(result && (_signer == address(0x0)))) {
+        if (!(result && (_signer != address(0x0)))) {
             require(_signer != address(0x0), "signer address cannot be 0");
             require(result, "signature recovery failed");
         }

--- a/packages/protocol/test/libs/LibEIP712.js
+++ b/packages/protocol/test/libs/LibEIP712.js
@@ -82,5 +82,47 @@ contract('LibEIP712', (accounts) => {
                 'signer address cannot be 0',
             );
         });
+
+        it('should fail when signature is invalid', async () => {
+            const aztecAccount = secp256k1.generateAccount();
+            const { signature, encodedTypedData } = signer.signNoteACEDomain(
+                libEIP712.address,
+                aztecAccount.address,
+                aztecAccount.privateKey,
+            );
+
+            const seg1 = signature[1].slice(2);
+            const v1 = padLeft('0', seg1.length);
+            expect(v1).not.to.equal(seg1);
+            const invalidSignature1 = signature[0] + v1 + signature[2].slice(2);
+            await truffleAssert.reverts(
+                libEIP712._recoverSignature(encodedTypedData, invalidSignature1),
+                'signer address cannot be 0',
+            );
+
+            const seg2 = signature[2].slice(2);
+            const v2 = padLeft('0', seg2.length);
+            expect(v2).not.to.equal(seg2);
+            const invalidSignature2 = signature[0] + signature[1].slice(2) + v2;
+            await truffleAssert.reverts(
+                libEIP712._recoverSignature(encodedTypedData, invalidSignature2),
+                'signer address cannot be 0',
+            );
+        });
+
+        it('should fail when signature has wrong length', async () => {
+            const aztecAccount = secp256k1.generateAccount();
+            const { signature, encodedTypedData } = signer.signNoteACEDomain(
+                libEIP712.address,
+                aztecAccount.address,
+                aztecAccount.privateKey,
+            );
+
+            const invalidSignature2 = signature[0] + signature[1].slice(2) + signature[2].slice(2) + '10';
+            await truffleAssert.reverts(
+                libEIP712._recoverSignature(encodedTypedData, invalidSignature2),
+                'signature recovery failed',
+            );
+        });
     });
 });


### PR DESCRIPTION
Should enter the if statement when result is true but signer address is 0
