### PR TITLE
feat(protocol): add ability to mint on initialisation

### DIFF
--- a/packages/protocol/contracts/ERC1724/ZkAssetAdjustable.sol
+++ b/packages/protocol/contracts/ERC1724/ZkAssetAdjustable.sol
@@ -30,7 +30,7 @@ contract ZkAssetAdjustable is ZkAssetMintableBase, ZkAssetBurnableBase {
         true // canAdjustSupply
     ) {
         if (_optionalMintProofId != 0 && _optionalInitialisationMint.length != 0) {
-            _confidentialMint(_optionalMintProofId, _optionalInitialisationMint, msg.sender);
+            confidentialMint(_optionalMintProofId, _optionalInitialisationMint);
         }
     }
 }

--- a/packages/protocol/contracts/ERC1724/ZkAssetAdjustable.sol
+++ b/packages/protocol/contracts/ERC1724/ZkAssetAdjustable.sol
@@ -20,13 +20,18 @@ contract ZkAssetAdjustable is ZkAssetMintableBase, ZkAssetBurnableBase {
     constructor(
         address _aceAddress,
         address _linkedTokenAddress,
-        uint256 _scalingFactor
+        uint256 _scalingFactor,
+        uint24 _optionalMintProofId,
+        bytes memory _optionalInitialisationMint
     ) public ZkAssetOwnableBase(
         _aceAddress,
         _linkedTokenAddress,
         _scalingFactor,
         true // canAdjustSupply
     ) {
+        if (_optionalMintProofId != 0 && _optionalInitialisationMint.length != 0) {
+            _confidentialMint(_optionalMintProofId, _optionalInitialisationMint, msg.sender);
+        }
     }
 }
 

--- a/packages/protocol/contracts/ERC1724/ZkAssetMintable.sol
+++ b/packages/protocol/contracts/ERC1724/ZkAssetMintable.sol
@@ -31,7 +31,7 @@ contract ZkAssetMintable is ZkAssetMintableBase {
         true // canAdjustSupply
     ) {
         if (_optionalMintProofId != 0 && _optionalInitialisationMint.length != 0) {
-            _confidentialMint(_optionalMintProofId, _optionalInitialisationMint, msg.sender);
+            confidentialMint(_optionalMintProofId, _optionalInitialisationMint);
         }
     }
 }

--- a/packages/protocol/contracts/ERC1724/ZkAssetMintable.sol
+++ b/packages/protocol/contracts/ERC1724/ZkAssetMintable.sol
@@ -21,13 +21,18 @@ contract ZkAssetMintable is ZkAssetMintableBase {
     constructor(
         address _aceAddress,
         address _linkedTokenAddress,
-        uint256 _scalingFactor
+        uint256 _scalingFactor,
+        uint24 _optionalMintProofId,
+        bytes memory _optionalInitialisationMint
     ) public ZkAssetOwnableBase(
         _aceAddress,
         _linkedTokenAddress,
         _scalingFactor,
         true // canAdjustSupply
     ) {
+        if (_optionalMintProofId != 0 && _optionalInitialisationMint.length != 0) {
+            _confidentialMint(_optionalMintProofId, _optionalInitialisationMint, msg.sender);
+        }
     }
 }
 

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetBurnableBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetBurnableBase.sol
@@ -30,7 +30,7 @@ contract ZkAssetBurnableBase is ZkAssetOwnableBase {
     function confidentialBurn(uint24 _proof, bytes calldata _proofData) external onlyOwner {
         require(_proofData.length != 0, "proof invalid");
 
-        (bytes memory _proofOutputs) = ace.burn(_proof, _proofData, msg.sender);
+        (bytes memory _proofOutputs) = ace.burn(_proof, _proofData, owner());
 
         (, bytes memory newTotal, ,) = _proofOutputs.get(0).extractProofOutput();
 

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetBurnableBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetBurnableBase.sol
@@ -30,7 +30,7 @@ contract ZkAssetBurnableBase is ZkAssetOwnableBase {
     function confidentialBurn(uint24 _proof, bytes calldata _proofData) external onlyOwner {
         require(_proofData.length != 0, "proof invalid");
 
-        (bytes memory _proofOutputs) = ace.burn(_proof, _proofData, address(this));
+        (bytes memory _proofOutputs) = ace.burn(_proof, _proofData, msg.sender);
 
         (, bytes memory newTotal, ,) = _proofOutputs.get(0).extractProofOutput();
 

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetMintableBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetMintableBase.sol
@@ -35,7 +35,7 @@ contract ZkAssetMintableBase is ZkAssetOwnableBase {
     {
         require(_proofData.length != 0, "proof invalid");
 
-        (bytes memory _proofOutputs) = ace.mint(_proof, _proofData, msg.sender);
+        (bytes memory _proofOutputs) = ace.mint(_proof, _proofData, owner());
 
         (, bytes memory newTotal, ,) = _proofOutputs.get(0).extractProofOutput();
 

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetMintableBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetMintableBase.sol
@@ -30,9 +30,27 @@ contract ZkAssetMintableBase is ZkAssetOwnableBase {
     * @param _proofData - bytes array of proof data, outputted from a proof construction
     */
     function confidentialMint(uint24 _proof, bytes calldata _proofData) external onlyOwner {
+        _confidentialMint(_proof, _proofData, address(this));
+    }
+
+    /**
+    * @dev Internal function executing a minting procedure. Takes in a _proofSender argument.
+    *   If called from the constructor, that _proofSender will be the owner of the zkAsset, otherwise
+    *   will be address(this)
+    *
+    * @param _proof - uint24 variable which acts as a unique identifier for the proof which
+    * _proofOutput is being submitted. _proof contains three concatenated uint8 variables:
+    * 1) epoch number 2) category number 3) ID number for the proof
+    * @param _proofData - bytes array of proof data, outputted from a proof construction
+    * @param _proofSender - address of the proof sender
+    */
+    function _confidentialMint(uint24 _proof, bytes memory _proofData, address _proofSender)
+        internal
+        onlyOwner
+    {
         require(_proofData.length != 0, "proof invalid");
 
-        (bytes memory _proofOutputs) = ace.mint(_proof, _proofData, address(this));
+        (bytes memory _proofOutputs) = ace.mint(_proof, _proofData, _proofSender);
 
         (, bytes memory newTotal, ,) = _proofOutputs.get(0).extractProofOutput();
 
@@ -45,6 +63,7 @@ contract ZkAssetMintableBase is ZkAssetOwnableBase {
         logOutputNotes(mintedNotes);
         emit UpdateTotalMinted(noteHash, metadata);
     }
+
     /**
     * @dev Executes a basic unilateral, confidential transfer of AZTEC notes adapted for use with
     * a mintable ZkAsset.

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetMintableBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetMintableBase.sol
@@ -29,28 +29,13 @@ contract ZkAssetMintableBase is ZkAssetOwnableBase {
     * 1) epoch number 2) category number 3) ID number for the proof
     * @param _proofData - bytes array of proof data, outputted from a proof construction
     */
-    function confidentialMint(uint24 _proof, bytes calldata _proofData) external onlyOwner {
-        _confidentialMint(_proof, _proofData, address(this));
-    }
-
-    /**
-    * @dev Internal function executing a minting procedure. Takes in a _proofSender argument.
-    *   If called from the constructor, that _proofSender will be the owner of the zkAsset, otherwise
-    *   will be address(this)
-    *
-    * @param _proof - uint24 variable which acts as a unique identifier for the proof which
-    * _proofOutput is being submitted. _proof contains three concatenated uint8 variables:
-    * 1) epoch number 2) category number 3) ID number for the proof
-    * @param _proofData - bytes array of proof data, outputted from a proof construction
-    * @param _proofSender - address of the proof sender
-    */
-    function _confidentialMint(uint24 _proof, bytes memory _proofData, address _proofSender)
-        internal
+    function confidentialMint(uint24 _proof, bytes memory _proofData)
+        public
         onlyOwner
     {
         require(_proofData.length != 0, "proof invalid");
 
-        (bytes memory _proofOutputs) = ace.mint(_proof, _proofData, _proofSender);
+        (bytes memory _proofOutputs) = ace.mint(_proof, _proofData, msg.sender);
 
         (, bytes memory newTotal, ,) = _proofOutputs.get(0).extractProofOutput();
 

--- a/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
@@ -71,16 +71,9 @@ contract('ZkAssetAdjustable', (accounts) => {
         });
 
         it('should complete a mint operation', async () => {
-            const zkAssetAdjustable = await ZkAssetAdjustable.new(
-                ace.address,
-                erc20.address,
-                scalingFactor,
-                0,
-                [],
-                {
-                    from: accounts[0],
-                }
-            );
+            const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, 0, [], {
+                from: accounts[0],
+            });
 
             const sender = zkAssetAdjustable.address;
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
@@ -91,16 +84,9 @@ contract('ZkAssetAdjustable', (accounts) => {
         });
 
         it('should transfer minted value out of the note registry', async () => {
-            const zkAssetAdjustable = await ZkAssetAdjustable.new(
-                ace.address,
-                erc20.address,
-                scalingFactor,
-                0,
-                [],
-                {
-                    from: accounts[0],
-                }
-            );
+            const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, 0, [], {
+                from: accounts[0],
+            });
 
             const withdrawalPublicValue = 50;
             const erc20TotalSupply = (await erc20.totalSupply()).toNumber();
@@ -128,7 +114,7 @@ contract('ZkAssetAdjustable', (accounts) => {
             ]);
             const { receipt: transferReceipt } = await zkAssetAdjustable.confidentialTransfer(
                 withdrawalData,
-                withdrawalSignatures
+                withdrawalSignatures,
             );
 
             const erc20TotalSupplyAfterWithdrawal = (await erc20.totalSupply()).toNumber();
@@ -140,16 +126,9 @@ contract('ZkAssetAdjustable', (accounts) => {
         });
 
         it('should burn minted notes', async () => {
-            const zkAssetAdjustable = await ZkAssetAdjustable.new(
-                ace.address,
-                erc20.address,
-                scalingFactor,
-                0,
-                [],
-                {
-                    from: accounts[0],
-                }
-            );
+            const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, 0, [], {
+                from: accounts[0],
+            });
 
             const sender = zkAssetAdjustable.address;
             const mintValue = 50;
@@ -170,16 +149,9 @@ contract('ZkAssetAdjustable', (accounts) => {
         });
 
         it('should perform mint when using confidentialTransferFrom()', async () => {
-            const zkAssetAdjustable = await ZkAssetAdjustable.new(
-                ace.address,
-                erc20.address,
-                scalingFactor,
-                0,
-                [],
-                {
-                    from: accounts[0],
-                }
-            );
+            const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, 0, [], {
+                from: accounts[0],
+            });
 
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
             const delegateAddress = accounts[2];
@@ -238,16 +210,9 @@ contract('ZkAssetAdjustable', (accounts) => {
             const recipient1 = accounts[1];
             const delegateAddress = accounts[2];
 
-            const zkAssetAdjustable = await ZkAssetAdjustable.new(
-                ace.address,
-                erc20.address,
-                scalingFactor,
-                0,
-                [],
-                {
-                    from: accounts[0],
-                }
-            );
+            const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, 0, [], {
+                from: accounts[0],
+            });
             const depositOutputNoteValues = [20, 30];
             const depositOutputNotes = await helpers.getNotesForAccount(aztecAccount, depositOutputNoteValues);
 
@@ -335,16 +300,9 @@ contract('ZkAssetAdjustable', (accounts) => {
         });
 
         it('should fail if msg.sender is not owner', async () => {
-            const zkAssetAdjustable = await ZkAssetAdjustable.new(
-                ace.address,
-                erc20.address,
-                scalingFactor,
-                0,
-                [],
-                {
-                    from: accounts[0],
-                }
-            );
+            const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, 0, [], {
+                from: accounts[0],
+            });
 
             const sender = zkAssetAdjustable.address;
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
@@ -354,16 +312,9 @@ contract('ZkAssetAdjustable', (accounts) => {
         });
 
         it('should fail for unbalanced proof relation, totalInputs !== totalOutputs', async () => {
-            const zkAssetAdjustable = await ZkAssetAdjustable.new(
-                ace.address,
-                erc20.address,
-                scalingFactor,
-                0,
-                [],
-                {
-                    from: accounts[0],
-                }
-            );
+            const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, 0, [], {
+                from: accounts[0],
+            });
             const sender = zkAssetAdjustable.address;
             const newMintCounterValue = 50;
             const mintedNoteValues = [30, 30];

--- a/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
@@ -75,7 +75,7 @@ contract('ZkAssetAdjustable', (accounts) => {
                 from: accounts[0],
             });
 
-            const sender = zkAssetAdjustable.address;
+            const sender = accounts[0];
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
             const proof = new MintProof(zeroMintCounterNote, newMintCounterNote, mintedNotes, sender);
             const data = proof.encodeABI();
@@ -93,7 +93,7 @@ contract('ZkAssetAdjustable', (accounts) => {
             expect(erc20TotalSupply).to.equal(0);
             const initialBalance = (await erc20.balanceOf(accounts[1])).toNumber();
 
-            const mintSender = zkAssetAdjustable.address;
+            const mintSender = accounts[0];
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
 
             const proof = new MintProof(zeroMintCounterNote, newMintCounterNote, mintedNotes, mintSender);
@@ -130,7 +130,7 @@ contract('ZkAssetAdjustable', (accounts) => {
                 from: accounts[0],
             });
 
-            const sender = zkAssetAdjustable.address;
+            const sender = accounts[0];
             const mintValue = 50;
             const mintNotes = [20, 30];
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getCustomMintNotes(mintValue, mintNotes);
@@ -138,7 +138,7 @@ contract('ZkAssetAdjustable', (accounts) => {
             const data = proof.encodeABI();
             await zkAssetAdjustable.confidentialMint(MINT_PROOF, data, { from: accounts[0] });
 
-            const burnSender = zkAssetAdjustable.address;
+            const [burnSender] = accounts;
             const newBurnCounterNote = await note.create(aztecAccount.publicKey, mintValue);
             const zeroBurnCounterNote = await note.createZeroValueNote();
             const burnProof = new BurnProof(zeroBurnCounterNote, newBurnCounterNote, mintedNotes, burnSender);
@@ -163,7 +163,7 @@ contract('ZkAssetAdjustable', (accounts) => {
             expect(erc20TotalSupply).to.equal(0);
             expect(initialRecipientBalance).to.equal(0);
 
-            const mintSender = zkAssetAdjustable.address;
+            const mintSender = accounts[0];
             const proof = new MintProof(zeroMintCounterNote, newMintCounterNote, mintedNotes, mintSender);
             const data = proof.encodeABI();
             const { receipt: mintReceipt } = await zkAssetAdjustable.confidentialMint(MINT_PROOF, data);
@@ -304,7 +304,7 @@ contract('ZkAssetAdjustable', (accounts) => {
                 from: accounts[0],
             });
 
-            const sender = zkAssetAdjustable.address;
+            const sender = accounts[0];
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
             const proof = new MintProof(zeroMintCounterNote, newMintCounterNote, mintedNotes, sender);
             const data = proof.encodeABI();
@@ -315,7 +315,7 @@ contract('ZkAssetAdjustable', (accounts) => {
             const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, 0, [], {
                 from: accounts[0],
             });
-            const sender = zkAssetAdjustable.address;
+            const sender = accounts[0];
             const newMintCounterValue = 50;
             const mintedNoteValues = [30, 30];
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getCustomMintNotes(

--- a/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
@@ -71,9 +71,16 @@ contract('ZkAssetAdjustable', (accounts) => {
         });
 
         it('should complete a mint operation', async () => {
-            const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, {
-                from: accounts[0],
-            });
+            const zkAssetAdjustable = await ZkAssetAdjustable.new(
+                ace.address,
+                erc20.address,
+                scalingFactor,
+                0,
+                [],
+                {
+                    from: accounts[0],
+                }
+            );
 
             const sender = zkAssetAdjustable.address;
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
@@ -84,9 +91,16 @@ contract('ZkAssetAdjustable', (accounts) => {
         });
 
         it('should transfer minted value out of the note registry', async () => {
-            const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, {
-                from: accounts[0],
-            });
+            const zkAssetAdjustable = await ZkAssetAdjustable.new(
+                ace.address,
+                erc20.address,
+                scalingFactor,
+                0,
+                [],
+                {
+                    from: accounts[0],
+                }
+            );
 
             const withdrawalPublicValue = 50;
             const erc20TotalSupply = (await erc20.totalSupply()).toNumber();
@@ -114,7 +128,7 @@ contract('ZkAssetAdjustable', (accounts) => {
             ]);
             const { receipt: transferReceipt } = await zkAssetAdjustable.confidentialTransfer(
                 withdrawalData,
-                withdrawalSignatures,
+                withdrawalSignatures
             );
 
             const erc20TotalSupplyAfterWithdrawal = (await erc20.totalSupply()).toNumber();
@@ -126,9 +140,16 @@ contract('ZkAssetAdjustable', (accounts) => {
         });
 
         it('should burn minted notes', async () => {
-            const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, {
-                from: accounts[0],
-            });
+            const zkAssetAdjustable = await ZkAssetAdjustable.new(
+                ace.address,
+                erc20.address,
+                scalingFactor,
+                0,
+                [],
+                {
+                    from: accounts[0],
+                }
+            );
 
             const sender = zkAssetAdjustable.address;
             const mintValue = 50;
@@ -149,9 +170,16 @@ contract('ZkAssetAdjustable', (accounts) => {
         });
 
         it('should perform mint when using confidentialTransferFrom()', async () => {
-            const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, {
-                from: accounts[0],
-            });
+            const zkAssetAdjustable = await ZkAssetAdjustable.new(
+                ace.address,
+                erc20.address,
+                scalingFactor,
+                0,
+                [],
+                {
+                    from: accounts[0],
+                }
+            );
 
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
             const delegateAddress = accounts[2];
@@ -210,9 +238,16 @@ contract('ZkAssetAdjustable', (accounts) => {
             const recipient1 = accounts[1];
             const delegateAddress = accounts[2];
 
-            const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, {
-                from: sender,
-            });
+            const zkAssetAdjustable = await ZkAssetAdjustable.new(
+                ace.address,
+                erc20.address,
+                scalingFactor,
+                0,
+                [],
+                {
+                    from: accounts[0],
+                }
+            );
             const depositOutputNoteValues = [20, 30];
             const depositOutputNotes = await helpers.getNotesForAccount(aztecAccount, depositOutputNoteValues);
 
@@ -300,9 +335,16 @@ contract('ZkAssetAdjustable', (accounts) => {
         });
 
         it('should fail if msg.sender is not owner', async () => {
-            const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, {
-                from: accounts[0],
-            });
+            const zkAssetAdjustable = await ZkAssetAdjustable.new(
+                ace.address,
+                erc20.address,
+                scalingFactor,
+                0,
+                [],
+                {
+                    from: accounts[0],
+                }
+            );
 
             const sender = zkAssetAdjustable.address;
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
@@ -312,9 +354,16 @@ contract('ZkAssetAdjustable', (accounts) => {
         });
 
         it('should fail for unbalanced proof relation, totalInputs !== totalOutputs', async () => {
-            const zkAssetAdjustable = await ZkAssetAdjustable.new(ace.address, erc20.address, scalingFactor, {
-                from: accounts[0],
-            });
+            const zkAssetAdjustable = await ZkAssetAdjustable.new(
+                ace.address,
+                erc20.address,
+                scalingFactor,
+                0,
+                [],
+                {
+                    from: accounts[0],
+                }
+            );
             const sender = zkAssetAdjustable.address;
             const newMintCounterValue = 50;
             const mintedNoteValues = [30, 30];

--- a/packages/protocol/test/ERC1724/ZkAssetBurnable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetBurnable.js
@@ -110,7 +110,7 @@ contract('ZkAssetBurnable', (accounts) => {
             const expectedAceIntermediateBalance = new BN(-depositPublicValue).mul(scalingFactor).toNumber();
             expect(aceIntermediateBalance).to.equal(expectedAceIntermediateBalance);
 
-            const burnSender = zkAssetBurnable.address;
+            const [burnSender] = accounts;
             const burnProof = new BurnProof(zeroBurnCounterNote, newBurnCounterNote, burnNotes, burnSender);
             const burnData = burnProof.encodeABI(zkAssetBurnable.address);
 
@@ -177,7 +177,7 @@ contract('ZkAssetBurnable', (accounts) => {
             });
             await zkAssetBurnable.confidentialTransfer(depositData, depositSignatures);
 
-            const burnSender = zkAssetBurnable.address;
+            const [burnSender] = accounts;
             const burnProof = new BurnProof(zeroBurnCounterNote, newBurnCounterNote, burnNotes, burnSender);
             const burnData = burnProof.encodeABI(zkAssetBurnable.address);
 
@@ -217,7 +217,7 @@ contract('ZkAssetBurnable', (accounts) => {
             });
             await zkAssetBurnable.confidentialTransfer(depositData, depositSignatures);
 
-            const burnSender = zkAssetBurnable.address;
+            const [burnSender] = accounts;
 
             // Change a value of the burnedNote such that it doesn't satisfy a balancing relationship
             burnNotes[0] = await note.create(secp256k1.generateAccount().publicKey, 31);

--- a/packages/protocol/test/ERC1724/ZkAssetMintable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetMintable.js
@@ -71,16 +71,9 @@ contract('ZkAssetMintable', (accounts) => {
         });
 
         it('should complete a mint operation', async () => {
-            const zkAssetMintable = await ZkAssetMintable.new(
-                ace.address,
-                erc20.address,
-                scalingFactor,
-                0,
-                [],
-                {
-                    from: accounts[0],
-                }
-            );
+            const zkAssetMintable = await ZkAssetMintable.new(ace.address, erc20.address, scalingFactor, 0, [], {
+                from: accounts[0],
+            });
 
             const sender = zkAssetMintable.address;
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
@@ -96,32 +89,18 @@ contract('ZkAssetMintable', (accounts) => {
             const proof = new MintProof(zeroMintCounterNote, newMintCounterNote, mintedNotes, sender);
             const data = proof.encodeABI();
 
-            const zkAssetMintable = await ZkAssetMintable.new(
-                ace.address,
-                erc20.address,
-                scalingFactor,
-                MINT_PROOF,
-                data,
-                {
-                    from: accounts[0],
-                }
-            );
+            const zkAssetMintable = await ZkAssetMintable.new(ace.address, erc20.address, scalingFactor, MINT_PROOF, data, {
+                from: accounts[0],
+            });
 
             const mintedNote = await ace.getNote(zkAssetMintable.address, mintedNotes[0].noteHash);
-            expect(mintedNote.noteOwner).to.equal( aztecAccount.address);
+            expect(mintedNote.noteOwner).to.equal(aztecAccount.address);
         });
 
         it('should transfer minted value out of the note registry', async () => {
-            const zkAssetMintable = await ZkAssetMintable.new(
-                ace.address,
-                erc20.address,
-                scalingFactor,
-                0,
-                [],
-                {
-                    from: accounts[0],
-                }
-            );
+            const zkAssetMintable = await ZkAssetMintable.new(ace.address, erc20.address, scalingFactor, 0, [], {
+                from: accounts[0],
+            });
 
             const withdrawalPublicValue = 50;
             const erc20TotalSupply = (await erc20.totalSupply()).toNumber();
@@ -147,10 +126,7 @@ contract('ZkAssetMintable', (accounts) => {
                 aztecAccount,
                 aztecAccount,
             ]);
-            const { receipt: transferReceipt } = await zkAssetMintable.confidentialTransfer(
-                withdrawalData,
-                withdrawalSignatures
-            );
+            const { receipt: transferReceipt } = await zkAssetMintable.confidentialTransfer(withdrawalData, withdrawalSignatures);
 
             const erc20TotalSupplyAfterWithdrawal = (await erc20.totalSupply()).toNumber();
             expect(erc20TotalSupplyAfterWithdrawal).to.equal(withdrawalPublicValue * scalingFactor);
@@ -161,16 +137,9 @@ contract('ZkAssetMintable', (accounts) => {
         });
 
         it('should perform mint when using confidentialTransferFrom()', async () => {
-            const zkAssetMintable = await ZkAssetMintable.new(
-                ace.address,
-                erc20.address,
-                scalingFactor,
-                0,
-                [],
-                {
-                    from: accounts[0],
-                }
-            );
+            const zkAssetMintable = await ZkAssetMintable.new(ace.address, erc20.address, scalingFactor, 0, [], {
+                from: accounts[0],
+            });
 
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
             const delegateAddress = accounts[2];
@@ -229,16 +198,9 @@ contract('ZkAssetMintable', (accounts) => {
             const recipient1 = accounts[1];
             const delegateAddress = accounts[2];
 
-            const zkAssetMintable = await ZkAssetMintable.new(
-                ace.address,
-                erc20.address,
-                scalingFactor,
-                0,
-                [],
-                {
-                    from: sender,
-                }
-            );
+            const zkAssetMintable = await ZkAssetMintable.new(ace.address, erc20.address, scalingFactor, 0, [], {
+                from: sender,
+            });
             const depositOutputNoteValues = [20, 30];
             const depositOutputNotes = await helpers.getNotesForAccount(aztecAccount, depositOutputNoteValues);
 
@@ -326,16 +288,9 @@ contract('ZkAssetMintable', (accounts) => {
         });
 
         it('should fail if msg.sender is not owner', async () => {
-            const zkAssetMintable = await ZkAssetMintable.new(
-                ace.address,
-                erc20.address,
-                scalingFactor,
-                0,
-                [],
-                {
-                    from: accounts[0],
-                }
-            );
+            const zkAssetMintable = await ZkAssetMintable.new(ace.address, erc20.address, scalingFactor, 0, [], {
+                from: accounts[0],
+            });
 
             const sender = zkAssetMintable.address;
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
@@ -345,16 +300,9 @@ contract('ZkAssetMintable', (accounts) => {
         });
 
         it('should fail for unbalanced proof relation, totalInputs !== totalOutputs', async () => {
-            const zkAssetMintable = await ZkAssetMintable.new(
-                ace.address,
-                erc20.address,
-                scalingFactor,
-                0,
-                [],
-                {
-                    from: accounts[0],
-                }
-            );
+            const zkAssetMintable = await ZkAssetMintable.new(ace.address, erc20.address, scalingFactor, 0, [], {
+                from: accounts[0],
+            });
             const sender = zkAssetMintable.address;
             const newMintCounterValue = 50;
             const mintedNoteValues = [30, 30];

--- a/packages/protocol/test/ERC1724/ZkAssetMintable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetMintable.js
@@ -147,7 +147,10 @@ contract('ZkAssetMintable', (accounts) => {
                 aztecAccount,
                 aztecAccount,
             ]);
-            const { receipt: transferReceipt } = await zkAssetMintable.confidentialTransfer(withdrawalData, withdrawalSignatures);
+            const { receipt: transferReceipt } = await zkAssetMintable.confidentialTransfer(
+                withdrawalData,
+                withdrawalSignatures
+            );
 
             const erc20TotalSupplyAfterWithdrawal = (await erc20.totalSupply()).toNumber();
             expect(erc20TotalSupplyAfterWithdrawal).to.equal(withdrawalPublicValue * scalingFactor);

--- a/packages/protocol/test/ERC1724/ZkAssetMintable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetMintable.js
@@ -75,7 +75,7 @@ contract('ZkAssetMintable', (accounts) => {
                 from: accounts[0],
             });
 
-            const sender = zkAssetMintable.address;
+            const [sender] = accounts;
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
             const proof = new MintProof(zeroMintCounterNote, newMintCounterNote, mintedNotes, sender);
             const data = proof.encodeABI();
@@ -107,7 +107,7 @@ contract('ZkAssetMintable', (accounts) => {
             expect(erc20TotalSupply).to.equal(0);
             const initialBalance = (await erc20.balanceOf(accounts[1])).toNumber();
 
-            const mintSender = zkAssetMintable.address;
+            const [mintSender] = accounts;
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
 
             const proof = new MintProof(zeroMintCounterNote, newMintCounterNote, mintedNotes, mintSender);
@@ -151,7 +151,7 @@ contract('ZkAssetMintable', (accounts) => {
             expect(erc20TotalSupply).to.equal(0);
             expect(initialRecipientBalance).to.equal(0);
 
-            const mintSender = zkAssetMintable.address;
+            const [mintSender] = accounts;
             const proof = new MintProof(zeroMintCounterNote, newMintCounterNote, mintedNotes, mintSender);
             const data = proof.encodeABI();
             const { receipt: mintReceipt } = await zkAssetMintable.confidentialMint(MINT_PROOF, data);
@@ -292,7 +292,7 @@ contract('ZkAssetMintable', (accounts) => {
                 from: accounts[0],
             });
 
-            const sender = zkAssetMintable.address;
+            const [sender] = accounts;
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
             const proof = new MintProof(zeroMintCounterNote, newMintCounterNote, mintedNotes, sender);
             const data = proof.encodeABI();
@@ -303,7 +303,7 @@ contract('ZkAssetMintable', (accounts) => {
             const zkAssetMintable = await ZkAssetMintable.new(ace.address, erc20.address, scalingFactor, 0, [], {
                 from: accounts[0],
             });
-            const sender = zkAssetMintable.address;
+            const [sender] = accounts;
             const newMintCounterValue = 50;
             const mintedNoteValues = [30, 30];
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getCustomMintNotes(

--- a/packages/protocol/test/ERC1724/ZkAssetMintable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetMintable.js
@@ -71,9 +71,16 @@ contract('ZkAssetMintable', (accounts) => {
         });
 
         it('should complete a mint operation', async () => {
-            const zkAssetMintable = await ZkAssetMintable.new(ace.address, erc20.address, scalingFactor, {
-                from: accounts[0],
-            });
+            const zkAssetMintable = await ZkAssetMintable.new(
+                ace.address,
+                erc20.address,
+                scalingFactor,
+                0,
+                [],
+                {
+                    from: accounts[0],
+                }
+            );
 
             const sender = zkAssetMintable.address;
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
@@ -83,10 +90,38 @@ contract('ZkAssetMintable', (accounts) => {
             expect(receipt.status).to.equal(true);
         });
 
+        it('should deploy a zkAsset and complete a mint operation in a single transaction', async () => {
+            const [sender] = accounts;
+            const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
+            const proof = new MintProof(zeroMintCounterNote, newMintCounterNote, mintedNotes, sender);
+            const data = proof.encodeABI();
+
+            const zkAssetMintable = await ZkAssetMintable.new(
+                ace.address,
+                erc20.address,
+                scalingFactor,
+                MINT_PROOF,
+                data,
+                {
+                    from: accounts[0],
+                }
+            );
+
+            const mintedNote = await ace.getNote(zkAssetMintable.address, mintedNotes[0].noteHash);
+            expect(mintedNote.noteOwner).to.equal( aztecAccount.address);
+        });
+
         it('should transfer minted value out of the note registry', async () => {
-            const zkAssetMintable = await ZkAssetMintable.new(ace.address, erc20.address, scalingFactor, {
-                from: accounts[0],
-            });
+            const zkAssetMintable = await ZkAssetMintable.new(
+                ace.address,
+                erc20.address,
+                scalingFactor,
+                0,
+                [],
+                {
+                    from: accounts[0],
+                }
+            );
 
             const withdrawalPublicValue = 50;
             const erc20TotalSupply = (await erc20.totalSupply()).toNumber();
@@ -123,9 +158,16 @@ contract('ZkAssetMintable', (accounts) => {
         });
 
         it('should perform mint when using confidentialTransferFrom()', async () => {
-            const zkAssetMintable = await ZkAssetMintable.new(ace.address, erc20.address, scalingFactor, {
-                from: accounts[0],
-            });
+            const zkAssetMintable = await ZkAssetMintable.new(
+                ace.address,
+                erc20.address,
+                scalingFactor,
+                0,
+                [],
+                {
+                    from: accounts[0],
+                }
+            );
 
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
             const delegateAddress = accounts[2];
@@ -184,9 +226,16 @@ contract('ZkAssetMintable', (accounts) => {
             const recipient1 = accounts[1];
             const delegateAddress = accounts[2];
 
-            const zkAssetMintable = await ZkAssetMintable.new(ace.address, erc20.address, scalingFactor, {
-                from: sender,
-            });
+            const zkAssetMintable = await ZkAssetMintable.new(
+                ace.address,
+                erc20.address,
+                scalingFactor,
+                0,
+                [],
+                {
+                    from: sender,
+                }
+            );
             const depositOutputNoteValues = [20, 30];
             const depositOutputNotes = await helpers.getNotesForAccount(aztecAccount, depositOutputNoteValues);
 
@@ -274,9 +323,16 @@ contract('ZkAssetMintable', (accounts) => {
         });
 
         it('should fail if msg.sender is not owner', async () => {
-            const zkAssetMintable = await ZkAssetMintable.new(ace.address, erc20.address, scalingFactor, {
-                from: accounts[0],
-            });
+            const zkAssetMintable = await ZkAssetMintable.new(
+                ace.address,
+                erc20.address,
+                scalingFactor,
+                0,
+                [],
+                {
+                    from: accounts[0],
+                }
+            );
 
             const sender = zkAssetMintable.address;
             const { zeroMintCounterNote, newMintCounterNote, mintedNotes } = await getDefaultMintNotes();
@@ -286,9 +342,16 @@ contract('ZkAssetMintable', (accounts) => {
         });
 
         it('should fail for unbalanced proof relation, totalInputs !== totalOutputs', async () => {
-            const zkAssetMintable = await ZkAssetMintable.new(ace.address, erc20.address, scalingFactor, {
-                from: accounts[0],
-            });
+            const zkAssetMintable = await ZkAssetMintable.new(
+                ace.address,
+                erc20.address,
+                scalingFactor,
+                0,
+                [],
+                {
+                    from: accounts[0],
+                }
+            );
             const sender = zkAssetMintable.address;
             const newMintCounterValue = 50;
             const mintedNoteValues = [30, 30];


### PR DESCRIPTION
## Description

Added the ability to mint on the deploy of a zkAssetMintable, by adding parameters to the constructor of the mintable + adjustable contract and by adding an internal method which handles overwriting the _proofSender parameter.

A side effect of this feature is that minting txs will cost more gas, due to a change from calldata to memory for the _proofData parameter of confidentialMint.

## Testing instructions

`yarn test`

## Types of changes

* New feature (non-breaking change which adds functionality)

* Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
