### PR TITLE
Fix burn note event log

### DIFF
--- a/packages/protocol/contracts/ERC1724/base/ZkAssetBurnableBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetBurnableBase.sol
@@ -40,7 +40,7 @@ contract ZkAssetBurnableBase is ZkAssetOwnableBase {
         bytes32 noteHash,
         bytes memory metadata) = newTotal.get(0).extractNote();
 
-        logOutputNotes(burnedNotes);
+        logInputNotes(burnedNotes);
         emit UpdateTotalBurned(noteHash, metadata);
     }
 }


### PR DESCRIPTION
## Description
Minor bug fix in `ZkAssetBurnable.sol` - thanks to @LeilaWang  for spotting!

Burn notes are treated as `inputNotes` and are removed from a note registry on successful verification of a burn proof. When this happens, events are emitted mark their destruction.

Each note should have a `DestroyNote()` event emitted. However, at the moment in the `confidentialBurn()` method, `logOutputNotes(burnedNotes)` is called - this results in `CreateNote()` events being emitted. 

This PR corrects this to `logInputNotes(burnedNotes)`, resulting in the correct emission of `DestroyNote()` events. 
<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
