### PR TITLE
Feat make zk asset support joinsplit upgrade

### DIFF
--- a/packages/protocol/contracts/ACE/noteRegistry/NoteRegistryManager.sol
+++ b/packages/protocol/contracts/ACE/noteRegistry/NoteRegistryManager.sol
@@ -138,7 +138,7 @@ contract NoteRegistryManager is IAZTEC, Ownable {
 
     /**
     * @dev called when a mintable and convertible asset wants to perform an
-            action which putts the zero-knowledge and public
+            action which puts the zero-knowledge and public
             balance out of balance. For example, if minting in zero-knowledge, some
             public tokens need to be added to the pool
             managed by ACE, otherwise any private->public conversion runs the risk of not

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetMintableBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetMintableBase.sol
@@ -61,6 +61,8 @@ contract ZkAssetMintableBase is ZkAssetOwnableBase {
     * @param _signatures - array of the ECDSA signatures over all inputNotes
     */
     function confidentialTransfer(uint24 _proofId, bytes memory _proofData, bytes memory _signatures) public {
+        bool result = supportsProof(_proofId);
+        require(result == true, "expected proof to be supported");
         // Check that it's a balanced proof
         (, uint8 category, ) = _proofId.getProofComponents();
 
@@ -109,13 +111,16 @@ contract ZkAssetMintableBase is ZkAssetOwnableBase {
     * If public value is being transferred out of the ACE, and the minted value is greater than
     * ACE's token balance, then tokens will be minted from the linked ERC20 token using supplementTokens()
     *
-    * @param _proof - uint24 variable which acts as a unique identifier for the proof which
+    * @param _proofId - uint24 variable which acts as a unique identifier for the proof which
     * _proofOutput is being submitted. _proof contains three concatenated uint8 variables:
     * 1) epoch number 2) category number 3) ID number for the proof
     * @param _proofOutput - output of a zero-knowledge proof validation contract. Represents
     * transfer instructions for the ACE
     */
-    function confidentialTransferFrom(uint24 _proof, bytes memory _proofOutput) public {
+    function confidentialTransferFrom(uint24 _proofId, bytes memory _proofOutput) public {
+        bool result = supportsProof(_proofId);
+        require(result == true, "expected proof to be supported");
+
         (bytes memory inputNotes,
         bytes memory outputNotes,
         address publicOwner,
@@ -135,7 +140,7 @@ contract ZkAssetMintableBase is ZkAssetOwnableBase {
         }
 
 
-        ace.updateNoteRegistry(_proof, _proofOutput, msg.sender);
+        ace.updateNoteRegistry(_proofId, _proofOutput, msg.sender);
 
         logInputNotes(inputNotes);
         logOutputNotes(outputNotes);

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetMintableBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetMintableBase.sol
@@ -49,6 +49,40 @@ contract ZkAssetMintableBase is ZkAssetOwnableBase {
     }
 
     /**
+    * @dev Executes a basic unilateral, confidential transfer of AZTEC notes
+    * Will submit _proofData to the validateProof() function of the Cryptography Engine.
+    *
+    * Upon successfull verification, it will update note registry state - creating output notes and
+    * destroying input notes.
+    *
+    * @param _proofId - id of proof to be validated. Needs to be a balanced proof.
+    * @param _proofData - bytes variable outputted from a proof verification contract, representing
+    * transfer instructions for the ACE
+    * @param _signatures - array of the ECDSA signatures over all inputNotes
+    */
+    function confidentialTransfer(uint24 _proofId, bytes memory _proofData, bytes memory _signatures) public {
+        // Check that it's a balanced proof
+        (, uint8 category, ) = _proofId.getProofComponents();
+
+        require(category == uint8(ProofCategory.BALANCED), "this is not a balanced proof");
+        bytes memory proofOutputs = ace.validateProof(JOIN_SPLIT_PROOF, msg.sender, _proofData);
+        require(proofOutputs.length != 0, "proof invalid");
+
+        bytes memory proofOutput = proofOutputs.get(0);
+
+        (,
+        ,
+        ,
+        int256 publicValue) = proofOutput.extractProofOutput();
+
+        if (publicValue > 0) {
+            supplementTokens(uint256(publicValue));
+        }
+
+        confidentialTransferInternal(JOIN_SPLIT_PROOF, proofOutputs, _signatures, _proofData);
+    }
+
+    /**
     * @dev Executes a basic unilateral, confidential transfer of AZTEC notes adapted for use with
     * a mintable ZkAsset.
     *
@@ -64,36 +98,7 @@ contract ZkAssetMintableBase is ZkAssetOwnableBase {
     * @param _signatures ECDSA signatures over all input notes involved in the confidentialTransfer()
     */
     function confidentialTransfer(bytes memory _proofData, bytes memory _signatures) public {
-        bytes memory proofOutputs = ace.validateProof(JOIN_SPLIT_PROOF, msg.sender, _proofData);
-        require(proofOutputs.length != 0, "proof invalid");
-
-        bytes memory proofOutput = proofOutputs.get(0);
-
-        (,
-        ,
-        ,
-        int256 publicValue) = proofOutput.extractProofOutput();
-
-        (
-            ,
-            uint256 scalingFactor,
-            ,
-            ,
-            uint256 totalSupply,
-            ,
-            ,
-        ) = ace.getRegistry(address(this));
-        if (publicValue > 0) {
-            if (totalSupply < uint256(publicValue)) {
-                uint256 supplementValue = uint256(publicValue).sub(totalSupply);
-                ERC20Mintable(address(linkedToken)).mint(address(this), supplementValue.mul(scalingFactor));
-                ERC20Mintable(address(linkedToken)).approve(address(ace), supplementValue.mul(scalingFactor));
-
-                ace.supplementTokens(supplementValue);
-            }
-        }
-
-        confidentialTransferInternal(proofOutputs, _signatures, _proofData);
+        confidentialTransfer(JOIN_SPLIT_PROOF, _proofData, _signatures);
     }
 
     /**
@@ -103,7 +108,7 @@ contract ZkAssetMintableBase is ZkAssetOwnableBase {
 
     * If public value is being transferred out of the ACE, and the minted value is greater than
     * ACE's token balance, then tokens will be minted from the linked ERC20 token using supplementTokens()
-    * 
+    *
     * @param _proof - uint24 variable which acts as a unique identifier for the proof which
     * _proofOutput is being submitted. _proof contains three concatenated uint8 variables:
     * 1) epoch number 2) category number 3) ID number for the proof
@@ -115,7 +120,7 @@ contract ZkAssetMintableBase is ZkAssetOwnableBase {
         bytes memory outputNotes,
         address publicOwner,
         int256 publicValue) = _proofOutput.extractProofOutput();
-        
+
         uint256 length = inputNotes.getLength();
         for (uint i = 0; i < length; i += 1) {
             (, bytes32 noteHash, ) = inputNotes.get(i).extractNote();
@@ -125,24 +130,8 @@ contract ZkAssetMintableBase is ZkAssetOwnableBase {
             );
         }
 
-        (
-            ,
-            uint256 scalingFactor,
-            ,
-            ,
-            uint256 totalSupply,
-            ,
-            ,
-        ) = ace.getRegistry(address(this));
-
         if (publicValue > 0) {
-            if (totalSupply < uint256(publicValue)) {
-                uint256 supplementValue = uint256(publicValue).sub(totalSupply);
-                ERC20Mintable(address(linkedToken)).mint(address(this), supplementValue.mul(scalingFactor));
-                ERC20Mintable(address(linkedToken)).approve(address(ace), supplementValue.mul(scalingFactor));
-
-                ace.supplementTokens(supplementValue);
-            }
+            supplementTokens(uint256(publicValue));
         }
 
 
@@ -156,6 +145,36 @@ contract ZkAssetMintableBase is ZkAssetOwnableBase {
         }
         if (publicValue > 0) {
             emit RedeemTokens(publicOwner, uint256(publicValue));
+        }
+    }
+
+    /**
+    * @dev called when a mintable and convertible asset wants to perform an
+            action which puts the zero-knowledge and public
+            balance out of balance. For example, if minting in zero-knowledge, some
+            public tokens need to be added to the pool
+            managed by ACE, otherwise any private->public conversion runs the risk of not
+            having any public tokens to send.
+    *
+    * @param _value the value to be added
+    */
+    function supplementTokens(uint256 _value) internal {
+        (
+            ,
+            uint256 scalingFactor,
+            ,
+            ,
+            uint256 totalSupply,
+            ,
+            ,
+        ) = ace.getRegistry(address(this));
+
+        if (totalSupply < _value) {
+            uint256 supplementValue = _value.sub(totalSupply);
+            ERC20Mintable(address(linkedToken)).mint(address(this), supplementValue.mul(scalingFactor));
+            ERC20Mintable(address(linkedToken)).approve(address(ace), supplementValue.mul(scalingFactor));
+
+            ace.supplementTokens(supplementValue);
         }
     }
 }

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetOwnableBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetOwnableBase.sol
@@ -32,7 +32,8 @@ contract ZkAssetOwnableBase is ZkAssetBase, Ownable {
         _canAdjustSupply
     ) {
         // register the basic joinSplit as a valid proof
-        proofs[ace.latestEpoch()] = 17; // 16 + 1, recall that 1 is the join-split validator because of 1 * 256**(0)
+        // 16 + 1, recall that 1 is the join-split validator because of 1 * 256**(0)
+        proofs[ace.latestEpoch()] = 17;
     }
 
     function setProofs(

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetOwnableBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetOwnableBase.sol
@@ -31,6 +31,8 @@ contract ZkAssetOwnableBase is ZkAssetBase, Ownable {
         _scalingFactor,
         _canAdjustSupply
     ) {
+        // register the basic joinSplit as a valid proof
+        proofs[ace.latestEpoch()] = 17; // 16 + 1, recall that 1 is the join-split validator because of 1 * 256**(0)
     }
 
     function setProofs(

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetOwnableBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetOwnableBase.sol
@@ -40,10 +40,28 @@ contract ZkAssetOwnableBase is ZkAssetBase, Ownable {
         proofs[_epoch] = _proofs;
     }
 
-    function confidentialTransferFrom(uint24 _proof, bytes memory _proofOutput) public {
-        bool result = supportsProof(_proof);
+    /**
+    * @dev Executes a basic unilateral, confidential transfer of AZTEC notes
+    * Will submit _proofData to the validateProof() function of the Cryptography Engine.
+    *
+    * Upon successfull verification, it will update note registry state - creating output notes and
+    * destroying input notes.
+    *
+    * @param _proofId - id of proof to be validated. Needs to be a balanced proof.
+    * @param _proofData - bytes variable outputted from a proof verification contract, representing
+    * transfer instructions for the ACE
+    * @param _signatures - array of the ECDSA signatures over all inputNotes
+    */
+    function confidentialTransfer(uint24 _proofId, bytes memory _proofData, bytes memory _signatures) public {
+        bool result = supportsProof(_proofId);
         require(result == true, "expected proof to be supported");
-        super.confidentialTransferFrom(_proof, _proofOutput);
+        super.confidentialTransfer(_proofId, _proofData, _signatures);
+    }
+
+    function confidentialTransferFrom(uint24 _proofId, bytes memory _proofOutput) public {
+        bool result = supportsProof(_proofId);
+        require(result == true, "expected proof to be supported");
+        super.confidentialTransferFrom(_proofId, _proofOutput);
     }
 
     // @dev Return whether the proof is supported or not by this asset. Note that we have

--- a/packages/protocol/test/ERC1724/ZkAsset.js
+++ b/packages/protocol/test/ERC1724/ZkAsset.js
@@ -109,7 +109,7 @@ contract('ZkAsset', (accounts) => {
             const expectedBalancePostTransfer = balancePreTransfer.sub(transferAmountBN.mul(scalingFactor));
 
             await ace.publicApprove(zkAsset.address, proof.hash, depositPublicValue, { from: accounts[0] });
-            const { receipt } = await zkAsset.confidentialTransfer(data, signatures, { from: accounts[0] });
+            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](data, signatures, { from: accounts[0] });
             expect(receipt.status).to.equal(true);
 
             const balancePostTransfer = await erc20.balanceOf(accounts[0]);
@@ -141,7 +141,7 @@ contract('ZkAsset', (accounts) => {
             const expectedBalancePostTransfer = balancePreTransfer.sub(transferAmountBN.mul(scalingFactor));
 
             await ace.publicApprove(zkAsset.address, proof.hash, 200, { from: accounts[0] });
-            const { receipt } = await zkAsset.confidentialTransfer(data, signatures, { from: accounts[0] });
+            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](data, signatures, { from: accounts[0] });
             const balancePostTransfer = await erc20.balanceOf(accounts[0]);
             expect(balancePostTransfer.toString()).to.equal(expectedBalancePostTransfer.toString());
 
@@ -184,7 +184,7 @@ contract('ZkAsset', (accounts) => {
             const expectedBalancePostTransfer = balancePreTransfer.sub(transferAmountBN.mul(scalingFactor));
 
             await ace.publicApprove(zkAsset.address, proof.hash, 200, { from: accounts[0] });
-            const { receipt } = await zkAsset.confidentialTransfer(data, signatures, { from: accounts[0] });
+            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](data, signatures, { from: accounts[0] });
             const balancePostTransfer = await erc20.balanceOf(accounts[0]);
             expect(balancePostTransfer.toString()).to.equal(expectedBalancePostTransfer.toString());
 
@@ -213,7 +213,7 @@ contract('ZkAsset', (accounts) => {
             const depositSignatures = depositProof.constructSignatures(zkAsset.address, depositInputOwnerAccounts);
 
             await ace.publicApprove(zkAsset.address, depositProof.hash, 20, { from: accounts[0] });
-            await zkAsset.confidentialTransfer(depositData, depositSignatures, { from: accounts[0] });
+            await zkAsset.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
 
             const transferInputNotes = depositOutputNotes;
             const transferInputOwnerAccounts = [aztecAccount];
@@ -230,7 +230,7 @@ contract('ZkAsset', (accounts) => {
             const withdrawData = withdrawProof.encodeABI(zkAsset.address);
             const withdrawSignatures = withdrawProof.constructSignatures(zkAsset.address, transferInputOwnerAccounts);
 
-            const { receipt } = await zkAsset.confidentialTransfer(withdrawData, withdrawSignatures, { from: accounts[0] });
+            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](withdrawData, withdrawSignatures, { from: accounts[0] });
             expect(receipt.status).to.equal(true);
         });
 
@@ -344,7 +344,7 @@ contract('ZkAsset', (accounts) => {
             const signatures = proof.constructSignatures(zkAssetTest.address, depositInputOwnerAccounts);
 
             await ace.publicApprove(zkAssetTest.address, proof.hash, 200, { from: accounts[0] });
-            const { receipt: depositReceipt } = await zkAssetTest.confidentialTransfer(data, signatures, { from: accounts[0] });
+            const { receipt: depositReceipt } = await zkAssetTest.methods['confidentialTransfer(bytes,bytes)'](data, signatures, { from: accounts[0] });
 
             const updatedMetaData = randomHex(265);
             const updatedMetaDataLength = updatedMetaData.length;
@@ -381,7 +381,7 @@ contract('ZkAsset', (accounts) => {
             const signatures = proof.constructSignatures(zkAssetTest.address, depositInputOwnerAccounts);
 
             await ace.publicApprove(zkAssetTest.address, proof.hash, depositPublicValue, { from: accounts[0] });
-            const { receipt } = await zkAssetTest.confidentialTransfer(data, signatures, { from: accounts[0] });
+            const { receipt } = await zkAssetTest.methods['confidentialTransfer(bytes,bytes)'](data, signatures, { from: accounts[0] });
             expect(receipt.status).to.equal(true);
 
             // for the purposes of the test, assuming that just one address is being approved
@@ -670,7 +670,7 @@ contract('ZkAsset', (accounts) => {
             const signatures = proof.constructSignatures(zkAsset.address, depositInputOwnerAccounts);
 
             await ace.publicApprove(zkAsset.address, proof.hash, 200, { from: accounts[0] });
-            await zkAsset.confidentialTransfer(data, signatures, { from: accounts[0] });
+            await zkAsset.methods['confidentialTransfer(bytes,bytes)'](data, signatures, { from: accounts[0] });
 
             const updatedMetaData = randomHex(265);
             await truffleAssert.reverts(

--- a/packages/protocol/test/ERC1724/ZkAsset.js
+++ b/packages/protocol/test/ERC1724/ZkAsset.js
@@ -258,7 +258,7 @@ contract('ZkAsset', (accounts) => {
             const depositSignatures = depositProof.constructSignatures(zkAsset.address, depositInputOwnerAccounts);
 
             await ace.publicApprove(zkAsset.address, depositProof.hash, depositPublicValue, { from: accounts[0] });
-            await zkAsset.confidentialTransfer(depositData, depositSignatures);
+            await zkAsset.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
             const withdrawalProof = new JoinSplitProof(
                 transferInputNotes,
                 transferOutputNotes,
@@ -269,7 +269,7 @@ contract('ZkAsset', (accounts) => {
 
             const transferData = withdrawalProof.encodeABI(zkAsset.address);
             const transferSignatures = withdrawalProof.constructSignatures(zkAsset.address, transferInputOwnerAccounts);
-            const { receipt } = await zkAsset.confidentialTransfer(transferData, transferSignatures);
+            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, transferSignatures, { from: accounts[0] });
             expect(receipt.status).to.equal(true);
         });
 
@@ -302,7 +302,7 @@ contract('ZkAsset', (accounts) => {
             const depositData = depositProof.encodeABI(zkAsset.address);
             const depositSignatures = depositProof.constructSignatures(zkAsset.address, depositInputOwnerAccounts);
             await ace.publicApprove(zkAsset.address, depositProof.hash, depositPublicValue, { from: accounts[0] });
-            await zkAsset.confidentialTransfer(depositData, depositSignatures);
+            await zkAsset.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
 
             const transferProof = new JoinSplitProof(
                 transferInputNotes,
@@ -314,7 +314,7 @@ contract('ZkAsset', (accounts) => {
 
             const transferData = transferProof.encodeABI(JoinSplitValidator.address);
             const transferSignatures = transferProof.constructSignatures(zkAsset.address, transferInputOwnerAccounts);
-            const { receipt } = await zkAsset.confidentialTransfer(transferData, transferSignatures);
+            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, transferSignatures, { from: accounts[0] });
             expect(receipt.status).to.equal(true);
         });
 
@@ -430,7 +430,7 @@ contract('ZkAsset', (accounts) => {
 
             const malformedProofData = `0x0123${data.slice(6)}`;
             // no error message because it throws in assembly
-            await truffleAssert.reverts(zkAsset.confidentialTransfer(malformedProofData, signatures));
+            await truffleAssert.reverts(zkAsset.methods['confidentialTransfer(bytes,bytes)'](malformedProofData, signatures));
         });
 
         it('should should fail to create zkAsset if 0x0 is linked token address', async () => {
@@ -463,7 +463,7 @@ contract('ZkAsset', (accounts) => {
             const depositSignatures = depositProof.constructSignatures(zkAsset.address, depositInputOwnerAccounts);
 
             await ace.publicApprove(zkAsset.address, depositProof.hash, depositPublicValue, { from: accounts[0] });
-            await zkAsset.confidentialTransfer(depositData, depositSignatures);
+            await zkAsset.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
 
             const withdrawalProof = new JoinSplitProof(
                 transferInputNotes,
@@ -479,7 +479,7 @@ contract('ZkAsset', (accounts) => {
             const zeroSignature = new Array(length).fill(0).join('');
             const zeroSignatures = `0x${zeroSignature + zeroSignature + zeroSignature}`;
 
-            await truffleAssert.reverts(zkAsset.confidentialTransfer(transferData, zeroSignatures));
+            await truffleAssert.reverts(zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, zeroSignatures));
         });
 
         it('should fail if malformed signatures are provided', async () => {
@@ -506,7 +506,7 @@ contract('ZkAsset', (accounts) => {
             const depositSignatures = depositProof.constructSignatures(zkAsset.address, depositInputOwnerAccounts);
 
             await ace.publicApprove(zkAsset.address, depositProof.hash, depositPublicValue, { from: accounts[0] });
-            await zkAsset.confidentialTransfer(depositData, depositSignatures);
+            await zkAsset.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
 
             const withdrawalProof = new JoinSplitProof(
                 transferInputNotes,
@@ -521,7 +521,7 @@ contract('ZkAsset', (accounts) => {
             const malformedSignature = padLeft(crypto.randomBytes(32).toString('hex'));
             const malformedSignatures = `0x${malformedSignature + malformedSignature + malformedSignature}`;
 
-            await truffleAssert.reverts(zkAsset.confidentialTransfer(transferData, malformedSignatures));
+            await truffleAssert.reverts(zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, malformedSignatures));
         });
 
         it('should fail if different note owner signs the transaction', async () => {
@@ -548,7 +548,7 @@ contract('ZkAsset', (accounts) => {
             const depositSignatures = depositProof.constructSignatures(zkAsset.address, depositInputOwnerAccounts);
 
             await ace.publicApprove(zkAsset.address, depositProof.hash, depositPublicValue, { from: accounts[0] });
-            await zkAsset.confidentialTransfer(depositData, depositSignatures);
+            await zkAsset.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
 
             const malformedInputNoteOwners = [secp256k1.generateAccount(), secp256k1.generateAccount()];
 
@@ -563,7 +563,7 @@ contract('ZkAsset', (accounts) => {
             const transferData = withdrawalProof.encodeABI(zkAsset.address);
             const malformedtransferSignatures = withdrawalProof.constructSignatures(zkAsset.address, malformedInputNoteOwners);
 
-            await truffleAssert.reverts(zkAsset.confidentialTransfer(transferData, malformedtransferSignatures));
+            await truffleAssert.reverts(zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, malformedtransferSignatures));
         });
 
         it('should fail if validator address is malformed', async () => {
@@ -591,7 +591,7 @@ contract('ZkAsset', (accounts) => {
             const depositSignatures = depositProof.constructSignatures(randomValidatorAddress, depositInputOwnerAccounts);
 
             await ace.publicApprove(zkAsset.address, depositProof.hash, depositPublicValue, { from: accounts[0] });
-            await zkAsset.confidentialTransfer(depositData, depositSignatures);
+            await zkAsset.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
 
             const malformedInputNoteOwners = [secp256k1.generateAccount(), secp256k1.generateAccount()];
 
@@ -606,7 +606,7 @@ contract('ZkAsset', (accounts) => {
             const transferData = withdrawalProof.encodeABI(zkAsset.address);
             const malformedtransferSignatures = withdrawalProof.constructSignatures(zkAsset.address, malformedInputNoteOwners);
 
-            await truffleAssert.reverts(zkAsset.confidentialTransfer(transferData, malformedtransferSignatures));
+            await truffleAssert.reverts(zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, malformedtransferSignatures));
         });
 
         it('should fail if validator address is the joinSplit address', async () => {
@@ -633,7 +633,7 @@ contract('ZkAsset', (accounts) => {
             const depositSignatures = depositProof.constructSignatures(JoinSplitValidator.address, depositInputOwnerAccounts);
 
             await ace.publicApprove(zkAsset.address, depositProof.hash, depositPublicValue, { from: accounts[0] });
-            await zkAsset.confidentialTransfer(depositData, depositSignatures);
+            await zkAsset.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
 
             const malformedInputNoteOwners = [secp256k1.generateAccount(), secp256k1.generateAccount()];
 
@@ -648,7 +648,7 @@ contract('ZkAsset', (accounts) => {
             const transferData = withdrawalProof.encodeABI(zkAsset.address);
             const malformedtransferSignatures = withdrawalProof.constructSignatures(zkAsset.address, malformedInputNoteOwners);
 
-            await truffleAssert.reverts(zkAsset.confidentialTransfer(transferData, malformedtransferSignatures));
+            await truffleAssert.reverts(zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, malformedtransferSignatures));
         });
 
         it('should fail to update note metaData if msg.sender !== noteOwner or on approved noteAccess mapping', async () => {

--- a/packages/protocol/test/ERC1724/ZkAsset.js
+++ b/packages/protocol/test/ERC1724/ZkAsset.js
@@ -109,7 +109,9 @@ contract('ZkAsset', (accounts) => {
             const expectedBalancePostTransfer = balancePreTransfer.sub(transferAmountBN.mul(scalingFactor));
 
             await ace.publicApprove(zkAsset.address, proof.hash, depositPublicValue, { from: accounts[0] });
-            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](data, signatures, { from: accounts[0] });
+            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](data, signatures, {
+                from: accounts[0],
+            });
             expect(receipt.status).to.equal(true);
 
             const balancePostTransfer = await erc20.balanceOf(accounts[0]);
@@ -141,7 +143,9 @@ contract('ZkAsset', (accounts) => {
             const expectedBalancePostTransfer = balancePreTransfer.sub(transferAmountBN.mul(scalingFactor));
 
             await ace.publicApprove(zkAsset.address, proof.hash, 200, { from: accounts[0] });
-            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](data, signatures, { from: accounts[0] });
+            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](data, signatures, {
+                from: accounts[0],
+            });
             const balancePostTransfer = await erc20.balanceOf(accounts[0]);
             expect(balancePostTransfer.toString()).to.equal(expectedBalancePostTransfer.toString());
 
@@ -184,7 +188,9 @@ contract('ZkAsset', (accounts) => {
             const expectedBalancePostTransfer = balancePreTransfer.sub(transferAmountBN.mul(scalingFactor));
 
             await ace.publicApprove(zkAsset.address, proof.hash, 200, { from: accounts[0] });
-            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](data, signatures, { from: accounts[0] });
+            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](data, signatures, {
+                from: accounts[0],
+            });
             const balancePostTransfer = await erc20.balanceOf(accounts[0]);
             expect(balancePostTransfer.toString()).to.equal(expectedBalancePostTransfer.toString());
 
@@ -230,7 +236,9 @@ contract('ZkAsset', (accounts) => {
             const withdrawData = withdrawProof.encodeABI(zkAsset.address);
             const withdrawSignatures = withdrawProof.constructSignatures(zkAsset.address, transferInputOwnerAccounts);
 
-            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](withdrawData, withdrawSignatures, { from: accounts[0] });
+            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](withdrawData, withdrawSignatures, {
+                from: accounts[0],
+            });
             expect(receipt.status).to.equal(true);
         });
 
@@ -269,7 +277,9 @@ contract('ZkAsset', (accounts) => {
 
             const transferData = withdrawalProof.encodeABI(zkAsset.address);
             const transferSignatures = withdrawalProof.constructSignatures(zkAsset.address, transferInputOwnerAccounts);
-            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, transferSignatures, { from: accounts[0] });
+            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, transferSignatures, {
+                from: accounts[0],
+            });
             expect(receipt.status).to.equal(true);
         });
 
@@ -314,7 +324,9 @@ contract('ZkAsset', (accounts) => {
 
             const transferData = transferProof.encodeABI(JoinSplitValidator.address);
             const transferSignatures = transferProof.constructSignatures(zkAsset.address, transferInputOwnerAccounts);
-            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, transferSignatures, { from: accounts[0] });
+            const { receipt } = await zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, transferSignatures, {
+                from: accounts[0],
+            });
             expect(receipt.status).to.equal(true);
         });
 
@@ -344,7 +356,9 @@ contract('ZkAsset', (accounts) => {
             const signatures = proof.constructSignatures(zkAssetTest.address, depositInputOwnerAccounts);
 
             await ace.publicApprove(zkAssetTest.address, proof.hash, 200, { from: accounts[0] });
-            const { receipt: depositReceipt } = await zkAssetTest.methods['confidentialTransfer(bytes,bytes)'](data, signatures, { from: accounts[0] });
+            const { receipt: depositReceipt } = await zkAssetTest.methods['confidentialTransfer(bytes,bytes)'](data, signatures, {
+                from: accounts[0],
+            });
 
             const updatedMetaData = randomHex(265);
             const updatedMetaDataLength = updatedMetaData.length;
@@ -381,7 +395,9 @@ contract('ZkAsset', (accounts) => {
             const signatures = proof.constructSignatures(zkAssetTest.address, depositInputOwnerAccounts);
 
             await ace.publicApprove(zkAssetTest.address, proof.hash, depositPublicValue, { from: accounts[0] });
-            const { receipt } = await zkAssetTest.methods['confidentialTransfer(bytes,bytes)'](data, signatures, { from: accounts[0] });
+            const { receipt } = await zkAssetTest.methods['confidentialTransfer(bytes,bytes)'](data, signatures, {
+                from: accounts[0],
+            });
             expect(receipt.status).to.equal(true);
 
             // for the purposes of the test, assuming that just one address is being approved
@@ -563,7 +579,9 @@ contract('ZkAsset', (accounts) => {
             const transferData = withdrawalProof.encodeABI(zkAsset.address);
             const malformedtransferSignatures = withdrawalProof.constructSignatures(zkAsset.address, malformedInputNoteOwners);
 
-            await truffleAssert.reverts(zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, malformedtransferSignatures));
+            await truffleAssert.reverts(
+                zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, malformedtransferSignatures),
+            );
         });
 
         it('should fail if validator address is malformed', async () => {
@@ -606,7 +624,9 @@ contract('ZkAsset', (accounts) => {
             const transferData = withdrawalProof.encodeABI(zkAsset.address);
             const malformedtransferSignatures = withdrawalProof.constructSignatures(zkAsset.address, malformedInputNoteOwners);
 
-            await truffleAssert.reverts(zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, malformedtransferSignatures));
+            await truffleAssert.reverts(
+                zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, malformedtransferSignatures),
+            );
         });
 
         it('should fail if validator address is the joinSplit address', async () => {
@@ -648,7 +668,9 @@ contract('ZkAsset', (accounts) => {
             const transferData = withdrawalProof.encodeABI(zkAsset.address);
             const malformedtransferSignatures = withdrawalProof.constructSignatures(zkAsset.address, malformedInputNoteOwners);
 
-            await truffleAssert.reverts(zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, malformedtransferSignatures));
+            await truffleAssert.reverts(
+                zkAsset.methods['confidentialTransfer(bytes,bytes)'](transferData, malformedtransferSignatures),
+            );
         });
 
         it('should fail to update note metaData if msg.sender !== noteOwner or on approved noteAccess mapping', async () => {

--- a/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
@@ -55,7 +55,7 @@ const confidentialApprove = async (zkAssetAdjustable, delegateAddress, indexes, 
     );
 };
 
-contract.only('ZkAssetAdjustable', (accounts) => {
+contract('ZkAssetAdjustable', (accounts) => {
     describe('Success States', () => {
         let ace;
         let erc20;
@@ -185,7 +185,7 @@ contract.only('ZkAssetAdjustable', (accounts) => {
             );
             const withdrawalData = withdrawalProof.encodeABI(zkAssetAdjustable.address);
             await ace.validateProof(JOIN_SPLIT_PROOF, accounts[2], withdrawalData, { from: delegateAddress });
-            const { receipt: transferReceipt } = await zkAssetAdjustable.methods['confidentialTransferFrom(bytes,bytes)'](
+            const { receipt: transferReceipt } = await zkAssetAdjustable.confidentialTransferFrom(
                 JOIN_SPLIT_PROOF,
                 withdrawalProof.eth.output,
                 { from: delegateAddress },
@@ -263,7 +263,7 @@ contract.only('ZkAssetAdjustable', (accounts) => {
             const withdrawalData = withdrawalProof.encodeABI(zkAssetAdjustable.address);
 
             await ace.validateProof(JOIN_SPLIT_PROOF, delegateAddress, withdrawalData, { from: delegateAddress });
-            const { receipt: transferReceipt } = await zkAssetAdjustable.methods['confidentialTransferFrom(bytes,bytes)'](
+            const { receipt: transferReceipt } = await zkAssetAdjustable.confidentialTransferFrom(
                 JOIN_SPLIT_PROOF,
                 withdrawalProof.eth.output,
                 { from: delegateAddress },

--- a/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
@@ -239,9 +239,13 @@ contract('ZkAssetAdjustable', (accounts) => {
 
             await erc20.approve(ace.address, scalingFactor.mul(new BN(depositPublicValue)), { from: sender });
 
-            const { receipt: depositReceipt } = await zkAssetAdjustable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, {
-                from: sender,
-            });
+            const { receipt: depositReceipt } = await zkAssetAdjustable.methods['confidentialTransfer(bytes,bytes)'](
+                depositData,
+                depositSignatures,
+                {
+                    from: sender,
+                },
+            );
             expect(depositReceipt.status).to.equal(true);
 
             const intermediateAceBalance = (await erc20.balanceOf(ace.address)).toNumber();

--- a/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
@@ -239,7 +239,7 @@ contract('ZkAssetAdjustable', (accounts) => {
 
             await erc20.approve(ace.address, scalingFactor.mul(new BN(depositPublicValue)), { from: sender });
 
-            const { receipt: depositReceipt } = await zkAssetAdjustable.confidentialTransfer(depositData, depositSignatures, {
+            const { receipt: depositReceipt } = await zkAssetAdjustable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, {
                 from: sender,
             });
             expect(depositReceipt.status).to.equal(true);

--- a/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
@@ -55,7 +55,7 @@ const confidentialApprove = async (zkAssetAdjustable, delegateAddress, indexes, 
     );
 };
 
-contract('ZkAssetAdjustable', (accounts) => {
+contract.only('ZkAssetAdjustable', (accounts) => {
     describe('Success States', () => {
         let ace;
         let erc20;
@@ -112,7 +112,7 @@ contract('ZkAssetAdjustable', (accounts) => {
                 aztecAccount,
                 aztecAccount,
             ]);
-            const { receipt: transferReceipt } = await zkAssetAdjustable.confidentialTransfer(
+            const { receipt: transferReceipt } = await zkAssetAdjustable.methods['confidentialTransfer(bytes,bytes)'](
                 withdrawalData,
                 withdrawalSignatures,
             );
@@ -185,7 +185,7 @@ contract('ZkAssetAdjustable', (accounts) => {
             );
             const withdrawalData = withdrawalProof.encodeABI(zkAssetAdjustable.address);
             await ace.validateProof(JOIN_SPLIT_PROOF, accounts[2], withdrawalData, { from: delegateAddress });
-            const { receipt: transferReceipt } = await zkAssetAdjustable.confidentialTransferFrom(
+            const { receipt: transferReceipt } = await zkAssetAdjustable.methods['confidentialTransferFrom(bytes,bytes)'](
                 JOIN_SPLIT_PROOF,
                 withdrawalProof.eth.output,
                 { from: delegateAddress },
@@ -263,7 +263,7 @@ contract('ZkAssetAdjustable', (accounts) => {
             const withdrawalData = withdrawalProof.encodeABI(zkAssetAdjustable.address);
 
             await ace.validateProof(JOIN_SPLIT_PROOF, delegateAddress, withdrawalData, { from: delegateAddress });
-            const { receipt: transferReceipt } = await zkAssetAdjustable.confidentialTransferFrom(
+            const { receipt: transferReceipt } = await zkAssetAdjustable.methods['confidentialTransferFrom(bytes,bytes)'](
                 JOIN_SPLIT_PROOF,
                 withdrawalProof.eth.output,
                 { from: delegateAddress },

--- a/packages/protocol/test/ERC1724/ZkAssetMintable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetMintable.js
@@ -128,7 +128,7 @@ contract('ZkAssetMintable', (accounts) => {
                 aztecAccount,
                 aztecAccount,
             ]);
-            const { receipt: transferReceipt } = await zkAssetMintable.confidentialTransfer(withdrawalData, withdrawalSignatures);
+            const { receipt: transferReceipt } = await zkAssetMintable.methods['confidentialTransfer(bytes,bytes)'](withdrawalData, withdrawalSignatures, { from: accounts[0] });
 
             const erc20TotalSupplyAfterWithdrawal = (await erc20.totalSupply()).toNumber();
             expect(erc20TotalSupplyAfterWithdrawal).to.equal(withdrawalPublicValue * scalingFactor);
@@ -175,6 +175,7 @@ contract('ZkAssetMintable', (accounts) => {
             );
             const withdrawalData = withdrawalProof.encodeABI(zkAssetMintable.address);
             await ace.validateProof(JOIN_SPLIT_PROOF, accounts[2], withdrawalData, { from: delegateAddress });
+            
             const { receipt: transferReceipt } = await zkAssetMintable.confidentialTransferFrom(
                 JOIN_SPLIT_PROOF,
                 withdrawalProof.eth.output,
@@ -228,10 +229,8 @@ contract('ZkAssetMintable', (accounts) => {
             await ace.publicApprove(zkAssetMintable.address, depositProof.hash, depositPublicValue, { from: sender });
 
             await erc20.approve(ace.address, scalingFactor.mul(new BN(depositPublicValue)), { from: sender });
+            const { receipt: depositReceipt } = await zkAssetMintable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
 
-            const { receipt: depositReceipt } = await zkAssetMintable.confidentialTransfer(depositData, depositSignatures, {
-                from: sender,
-            });
             expect(depositReceipt.status).to.equal(true);
 
             const intermediateAceBalance = (await erc20.balanceOf(ace.address)).toNumber();

--- a/packages/protocol/test/ERC1724/ZkAssetMintable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetMintable.js
@@ -128,7 +128,11 @@ contract('ZkAssetMintable', (accounts) => {
                 aztecAccount,
                 aztecAccount,
             ]);
-            const { receipt: transferReceipt } = await zkAssetMintable.methods['confidentialTransfer(bytes,bytes)'](withdrawalData, withdrawalSignatures, { from: accounts[0] });
+            const { receipt: transferReceipt } = await zkAssetMintable.methods['confidentialTransfer(bytes,bytes)'](
+                withdrawalData,
+                withdrawalSignatures,
+                { from: accounts[0] },
+            );
 
             const erc20TotalSupplyAfterWithdrawal = (await erc20.totalSupply()).toNumber();
             expect(erc20TotalSupplyAfterWithdrawal).to.equal(withdrawalPublicValue * scalingFactor);
@@ -175,7 +179,7 @@ contract('ZkAssetMintable', (accounts) => {
             );
             const withdrawalData = withdrawalProof.encodeABI(zkAssetMintable.address);
             await ace.validateProof(JOIN_SPLIT_PROOF, accounts[2], withdrawalData, { from: delegateAddress });
-            
+
             const { receipt: transferReceipt } = await zkAssetMintable.confidentialTransferFrom(
                 JOIN_SPLIT_PROOF,
                 withdrawalProof.eth.output,
@@ -229,7 +233,11 @@ contract('ZkAssetMintable', (accounts) => {
             await ace.publicApprove(zkAssetMintable.address, depositProof.hash, depositPublicValue, { from: sender });
 
             await erc20.approve(ace.address, scalingFactor.mul(new BN(depositPublicValue)), { from: sender });
-            const { receipt: depositReceipt } = await zkAssetMintable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
+            const { receipt: depositReceipt } = await zkAssetMintable.methods['confidentialTransfer(bytes,bytes)'](
+                depositData,
+                depositSignatures,
+                { from: accounts[0] },
+            );
 
             expect(depositReceipt.status).to.equal(true);
 

--- a/packages/protocol/test/ERC1724/ZkAssetOwnable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetOwnable.js
@@ -111,7 +111,7 @@ contract('ZkAssetOwnable', (accounts) => {
                 from: accounts[0],
             });
 
-            await zkAssetOwnable.confidentialTransfer(depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
             const transferProof = new JoinSplitProof(
                 transferInputNotes,
                 transferOutputNotes,
@@ -169,7 +169,7 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, {
                 from: accounts[0],
             });
-            await zkAssetOwnable.confidentialTransfer(depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
 
             const transferProof = new JoinSplitProof(
                 transferInputNotes,
@@ -219,7 +219,7 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, {
                 from: accounts[0],
             });
-            await zkAssetOwnable.confidentialTransfer(depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
 
             const transferProof = new JoinSplitProof(
                 transferInputNotes,
@@ -268,7 +268,7 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, {
                 from: accounts[0],
             });
-            await zkAssetOwnable.confidentialTransfer(depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
 
             const signature = signer.signNoteForConfidentialApprove(
                 zkAssetOwnable.address,
@@ -312,7 +312,7 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, {
                 from: accounts[0],
             });
-            await zkAssetOwnable.confidentialTransfer(depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
 
             const transferProof = new JoinSplitProof(
                 transferInputNotes,
@@ -325,7 +325,7 @@ contract('ZkAssetOwnable', (accounts) => {
 
             const transferSignatures = transferProof.constructSignatures(zkAssetOwnable.address, transferInputOwnerAccounts);
 
-            await zkAssetOwnable.confidentialTransfer(transferData, transferSignatures);
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](transferData, transferSignatures);
 
             const signature = signer.signNoteForConfidentialApprove(
                 zkAssetOwnable.address,
@@ -360,7 +360,7 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, {
                 from: accounts[0],
             });
-            await zkAssetOwnable.confidentialTransfer(depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
 
             const emptySignature = '0x';
             await truffleAssert.reverts(
@@ -399,7 +399,7 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, {
                 from: accounts[0],
             });
-            await zkAssetOwnable.confidentialTransfer(depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
 
             const transferProof = new JoinSplitProof(
                 transferInputNotes,
@@ -442,7 +442,7 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, {
                 from: accounts[0],
             });
-            await zkAssetOwnable.confidentialTransfer(depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
             const transferProof = new JoinSplitProof(
                 transferInputNotes,
                 transferOutputNotes,

--- a/packages/protocol/test/ERC1724/ZkAssetOwnable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetOwnable.js
@@ -111,7 +111,9 @@ contract('ZkAssetOwnable', (accounts) => {
                 from: accounts[0],
             });
 
-            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, {
+                from: accounts[0],
+            });
             const transferProof = new JoinSplitProof(
                 transferInputNotes,
                 transferOutputNotes,
@@ -169,7 +171,9 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, {
                 from: accounts[0],
             });
-            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, {
+                from: accounts[0],
+            });
 
             const transferProof = new JoinSplitProof(
                 transferInputNotes,
@@ -219,7 +223,9 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, {
                 from: accounts[0],
             });
-            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, {
+                from: accounts[0],
+            });
 
             const transferProof = new JoinSplitProof(
                 transferInputNotes,
@@ -268,7 +274,9 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, {
                 from: accounts[0],
             });
-            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, {
+                from: accounts[0],
+            });
 
             const signature = signer.signNoteForConfidentialApprove(
                 zkAssetOwnable.address,
@@ -312,7 +320,9 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, {
                 from: accounts[0],
             });
-            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, {
+                from: accounts[0],
+            });
 
             const transferProof = new JoinSplitProof(
                 transferInputNotes,
@@ -360,7 +370,9 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, {
                 from: accounts[0],
             });
-            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, {
+                from: accounts[0],
+            });
 
             const emptySignature = '0x';
             await truffleAssert.reverts(
@@ -399,7 +411,9 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, {
                 from: accounts[0],
             });
-            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, {
+                from: accounts[0],
+            });
 
             const transferProof = new JoinSplitProof(
                 transferInputNotes,
@@ -442,7 +456,9 @@ contract('ZkAssetOwnable', (accounts) => {
             await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, {
                 from: accounts[0],
             });
-            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, { from: accounts[0] });
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, depositSignatures, {
+                from: accounts[0],
+            });
             const transferProof = new JoinSplitProof(
                 transferInputNotes,
                 transferOutputNotes,


### PR DESCRIPTION
## Description

This change fixes an issue with ZkAssets where, because of a hard coded proofId, any update to the JoinSplit validator could result in assets being locked out.


## Testing instructions

`yarn test`

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

