### PR TITLE
Use real g2 point to test CRS

### DIFF
--- a/packages/protocol/test/helpers/proof.js
+++ b/packages/protocol/test/helpers/proof.js
@@ -5,7 +5,7 @@ const { ProofType } = require('aztec.js');
 const bn128 = require('@aztec/bn128');
 const { constants } = require('@aztec/dev-utils');
 const BN = require('bn.js');
-const { keccak256, padLeft, randomHex } = require('web3-utils');
+const { keccak256, padLeft } = require('web3-utils');
 
 // kBar, aBar, gamma.x, gamma., sigma.x, sigma.y
 const zeroNote = Array(6).fill('0'.repeat(64));
@@ -13,7 +13,14 @@ const zeroNote = Array(6).fill('0'.repeat(64));
 // blindingFactor.x, blindingFactor.y
 const zeroBlindingFactors = Array(2).fill('0'.repeat(64));
 
-const fakeT2 = [randomHex(32), randomHex(32), randomHex(32), randomHex(32)];
+// Fake g2 point generated in a fake trusted setup. Complex numbers rearranged into
+// position expected by libff
+const fakeT2 = [
+    '0x297F1A1DEEF4C8A3709028B95B9C1FDEB4CE09A3113921933D950525D7864716',
+    '0x1241A123193A962F38BD839A4F002F967658A2080E41763FFD20B9A005794F0C',
+    '0xB0254AD2EA7179F031B0C854DD185559417FCFC3AFA5DFBD06565BDACA24C0A',
+    '0x78E97961554D14F31802CF063370F96C3ED42ED2F7EF2F64A6F3C15472580A5',
+];
 
 const FAKE_CRS = [`0x${bn128.H_X.toString(16)}`, `0x${bn128.H_Y.toString(16)}`, ...fakeT2];
 


### PR DESCRIPTION
## Summary
This PR refactors the tests around checking that a fake trusted setup public key is rejected by the pairing check in our validator contracts. 

It takes a valid g2 point, one that is on the curve, and passes that in as the `FAKE_CRS`. Previously, just a random point was passed. This random point was likely not on the `bn128` curve and so the validators were throwing for a different reason, other than the pairing check rejecting a fake trusted setup.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
