### PR TITLE
Fix bn128 clean script

### DIFF
--- a/packages/bn128/package.json
+++ b/packages/bn128/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "build": "webpack --config ./webpack.dev.js",
     "build:prod": "webpack --config ./webpack.prod.js",
-    "clean": "shx rm -rf ./lib",
+    "clean": "shx rm -rf ./dist || true",
     "lint": "eslint --ignore-path ../../.eslintignore .",
     "test": "NODE_ENV=TEST mocha ./test --bail --colors --exit --recursive --reporter spec --timeout 0 --trace-warnings",
     "watch": "yarn build --watch"


### PR DESCRIPTION
## Summary
The clean script for the `bn128` package was setup to remove a `lib` folder, rather than `dist`. The `bn128` package is webpacked, with the output being stored in a `dist` folder. 

This PR updates the `yarn clean` script to correctly remove the `dist` folder. 