### PR TITLE
Fix confidential approve

### DIFF
--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -53,17 +53,18 @@ signer.generateZKAssetDomainParams = (verifyingContract) => {
  * @param {string} verifyingContract address of target contract
  * @param {string} noteHash noteHash of the note being signed
  * @param {string} spender address of the note spender
+ * @param {bool} spenderApproval boolean determining whether the spender is being granted approval
+ * or revoked
  * @param {string} privateKey the private key of message signer
  * @returns {string} ECDSA signature parameters [r, s, v], formatted as 32-byte wide hex-strings
  */
-signer.signNoteForConfidentialApprove = (verifyingContract, noteHash, spender, privateKey) => {
+signer.signNoteForConfidentialApprove = (verifyingContract, noteHash, spender, spenderApproval, privateKey) => {
     const domain = signer.generateZKAssetDomainParams(verifyingContract);
     const schema = constants.eip712.NOTE_SIGNATURE;
-    const status = true;
     const message = {
         noteHash,
         spender,
-        status,
+        spenderApproval,
     };
 
     const { unformattedSignature } = signer.signTypedData(domain, schema, message, privateKey);

--- a/packages/aztec.js/test/signer/index.js
+++ b/packages/aztec.js/test/signer/index.js
@@ -112,11 +112,18 @@ describe('Signer', () => {
         it('signNoteForConfidentialApprove() should produce a well formed `v` ECDSA parameter', async () => {
             const { publicKey, privateKey } = secp256k1.generateAccount();
             const spender = randomHex(20);
+            const spenderApproval = true;
             const verifyingContract = randomHex(20);
             const testNoteValue = 10;
             const testNote = await note.create(publicKey, testNoteValue);
 
-            const signature = signer.signNoteForConfidentialApprove(verifyingContract, testNote.noteHash, spender, privateKey);
+            const signature = signer.signNoteForConfidentialApprove(
+                verifyingContract,
+                testNote.noteHash,
+                spender,
+                spenderApproval,
+                privateKey,
+            );
             const v = parseInt(signature.slice(130, 132), 16);
             expect(v).to.be.oneOf([27, 28]);
         });
@@ -125,10 +132,17 @@ describe('Signer', () => {
             const { publicKey, privateKey } = secp256k1.generateAccount();
             const spender = randomHex(20);
             const verifyingContract = randomHex(20);
+            const spenderApproval = true;
             const testNoteValue = 10;
             const testNote = await note.create(publicKey, testNoteValue);
 
-            const signature = signer.signNoteForConfidentialApprove(verifyingContract, testNote.noteHash, spender, privateKey);
+            const signature = signer.signNoteForConfidentialApprove(
+                verifyingContract,
+                testNote.noteHash,
+                spender,
+                spenderApproval,
+                privateKey,
+            );
 
             const r = Buffer.from(signature.slice(2, 66), 'hex');
             const s = Buffer.from(signature.slice(66, 130), 'hex');
@@ -139,7 +153,7 @@ describe('Signer', () => {
             const message = {
                 noteHash: testNote.noteHash,
                 spender,
-                status: true,
+                spenderApproval,
             };
             const { encodedTypedData } = signer.signTypedData(domain, schema, message, privateKey);
             const messageHash = Buffer.from(encodedTypedData.slice(2), 'hex');
@@ -151,6 +165,7 @@ describe('Signer', () => {
         it('signNoteForConfidentialApprove() should produce same signature as MetaMask signing function', async () => {
             const aztecAccount = secp256k1.generateAccount();
             const spender = randomHex(20);
+            const spenderApproval = true;
             const verifyingContract = randomHex(20);
             const testNoteValue = 10;
             const testNote = await note.create(aztecAccount.publicKey, testNoteValue);
@@ -165,7 +180,7 @@ describe('Signer', () => {
                     NoteSignature: [
                         { name: 'noteHash', type: 'bytes32' },
                         { name: 'spender', type: 'address' },
-                        { name: 'status', type: 'bool' },
+                        { name: 'spenderApproval', type: 'bool' },
                     ],
                     EIP712Domain: [
                         { name: 'name', type: 'string' },
@@ -177,7 +192,7 @@ describe('Signer', () => {
                 message: {
                     noteHash: testNote.noteHash,
                     spender,
-                    status: true,
+                    spenderApproval,
                 },
             };
 
@@ -185,6 +200,7 @@ describe('Signer', () => {
                 verifyingContract,
                 testNote.noteHash,
                 spender,
+                spenderApproval,
                 aztecAccount.privateKey,
             );
 

--- a/packages/dev-utils/src/constants.js
+++ b/packages/dev-utils/src/constants.js
@@ -139,7 +139,7 @@ constants.eip712 = {
             NoteSignature: [
                 { name: 'noteHash', type: 'bytes32' },
                 { name: 'spender', type: 'address' },
-                { name: 'status', type: 'bool' },
+                { name: 'spenderApproval', type: 'bool' },
             ],
             EIP712Domain: EIP712_DOMAIN,
         },

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
@@ -47,6 +47,7 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
     mapping(bytes32 => mapping(address => bool)) public confidentialApproved;
     mapping(bytes32 => uint256) public metaDataTimeLog;
     mapping(bytes32 => uint256) public noteAccess;
+    mapping(bytes32 => bool) public signatureLog;
 
 
     constructor(
@@ -135,6 +136,11 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
     ) public {
         ( uint8 status, , , ) = ace.getNote(address(this), _noteHash);
         require(status == 1, "only unspent notes can be approved");
+
+        bytes32 signatureHash = keccak256(abi.encodePacked(_signature));
+        require(signatureLog[signatureHash] != true, "signature has already been used");
+        signatureLog[signatureHash] = true;
+
         bytes32 _hashStruct = keccak256(abi.encode(
                 NOTE_SIGNATURE_TYPEHASH,
                 _noteHash,

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
@@ -122,7 +122,7 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
     *
     * @param _noteHash - keccak256 hash of the note coordinates (gamma and sigma)
     * @param _spender - address being approved to spend the note
-    * @param _status - defines whether the _spender address is being approved to spend the
+    * @param _spenderApproval - defines whether the _spender address is being approved to spend the
     * note, or if permission is being revoked
     * @param _signature - ECDSA signature from the note owner that validates the
     * confidentialApprove() instruction
@@ -130,7 +130,7 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
     function confidentialApprove(
         bytes32 _noteHash,
         address _spender,
-        bool _status,
+        bool _spenderApproval,
         bytes memory _signature
     ) public {
         ( uint8 status, , , ) = ace.getNote(address(this), _noteHash);
@@ -143,7 +143,7 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
         ));
 
         validateSignature(_hashStruct, _noteHash, _signature);
-        confidentialApproved[_noteHash][_spender] = _status;
+        confidentialApproved[_noteHash][_spender] = _spenderApproval;
     }
 
     /**

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
@@ -28,7 +28,7 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
         "NoteSignature(",
             "bytes32 noteHash,",
             "address spender,",
-            "bool status",
+            "bool spenderApproval",
         ")"
     ));
     
@@ -139,7 +139,7 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
                 NOTE_SIGNATURE_TYPEHASH,
                 _noteHash,
                 _spender,
-                status
+                _spenderApproval
         ));
 
         validateSignature(_hashStruct, _noteHash, _signature);

--- a/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetAdjustable.js
@@ -41,12 +41,14 @@ const getCustomMintNotes = async (newMintCounterValue, mintedNoteValues) => {
 };
 
 const confidentialApprove = async (zkAssetAdjustable, delegateAddress, indexes, notes, ownerAccount) => {
+    const spenderApproval = true;
     await Promise.all(
         indexes.map((i) => {
             const signature = signer.signNoteForConfidentialApprove(
                 zkAssetAdjustable.address,
                 notes[i].noteHash,
                 delegateAddress,
+                spenderApproval,
                 ownerAccount.privateKey,
             );
             // eslint-disable-next-line no-await-in-loop

--- a/packages/protocol/test/ERC1724/ZkAssetMintable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetMintable.js
@@ -43,12 +43,14 @@ const getCustomMintNotes = async (newMintCounterValue, mintedNoteValues) => {
 };
 
 const confidentialApprove = async (zkAssetMintable, delegateAddress, indexes, notes, ownerAccount) => {
+    const spenderApproval = true;
     await Promise.all(
         indexes.map((i) => {
             const signature = signer.signNoteForConfidentialApprove(
                 zkAssetMintable.address,
                 notes[i].noteHash,
                 delegateAddress,
+                spenderApproval,
                 ownerAccount.privateKey,
             );
             // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
## Summary
Fix `confidentialApprove()` so that signature replay attacks can not be used to re-grant a spender note spending access once their permission has been revoked. 

<!--- Summarise your changes -->

## Description
The main fix is that a mapping `signatureLog` has been added to the `ZkAssetBase.sol` along with corresponding validation logic in `confidentialApprove()`. 

The mapping maps a signature hash to a bool, with the bool representing whether the signature has previously been presented:

```
mapping(bytes32 => bool) signatureLog
```

Whenever a signature is presented to `confidentialApprove()`, the following check is first performed to see if the hash of the signature is present in `signatureLog`. If it is, the transaction reverts.

If not, the transaction proceeds and an hash(signature):true entry is made to `signatureLog`.  

The `signNoteForConfidentialApprove()` method now also takes a `spenderApproval` variable rather than note`status`. In `confidentialApprove` there is a check to make sure that `status` is 1, so adding to the signature is redundant. Adding the `spenderApproval` variable ensures that a particular signature can only be used to either 1) grant permission, or 2) revoke permissionl

### Efficiency considerations
Granting approval using a `confidentialApprove()` is likely to be one of the most common `ZkAsset` functions called, therefore gas efficiency is key. 

I believe using a mapping for the permissioning is one of the most gas efficient ways to do this. Alternatives, such as storing presented signatures in an array and iterating through each time to check if the signature was already presented, are far more expensive. 


<!--- Describe your changes in detail -->

## Testing instructions
Additional tests have been added to `ZkAssetOwnable.js`:

_Success tests_
- 'should revoke confidentialApprove() permission granting': confirm that the revoke permission behaviour of `confidentialApprove()` works as expected

_Failure tests_
- 'should fail to perform a replay attack, by using a previous signature in confidentialApprove()': check that the fix prevents a replay attack

<!--- Please describe how reviewers can test your changes -->


