### PR TITLE
batchConfidentialApprove() on ZkAsset

### DIFF
--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -73,6 +73,36 @@ signer.signNoteForConfidentialApprove = (verifyingContract, noteHash, spender, s
 };
 
 /**
+ * Create an EIP712 ECDSA signature over an array of AZTEC notes, used to either grant or revoke delegation of note control
+ * to a third party using the batchConfidentialApprove() of a ZkAsset.
+ *
+ * ECSA signature is formatted as follows:
+ * - `r` and `s` occupy 32 bytes
+ * - `v` occupies 1 byte
+ * 
+ * @method signMultipleNotesForBatchConfidentialApprove
+ * @param {string} verifyingContract address of target contract
+ * @param {string[]} noteHashes array of the keccak256 hashes of notes, for which approval is being granted or revoked
+ * @param {string} spender address to which note control is being delegated
+ * @param {bool} spenderApproval boolean determining whether the spender is being granted approval
+ * @param {string} privateKey the private key of message signer
+ * @returns {string} ECDSA signature parameters [r, s, v], formatted as 32-byte wide hex-strings
+ */
+signer.signNotesForBatchConfidentialApprove = (verifyingContract, noteHashes, spender, spenderApproval, privateKey) => {
+    const domain = signer.generateZKAssetDomainParams(verifyingContract);
+    const schema = constants.eip712.MULTIPLE_NOTE_SIGNATURE;
+    const message = {
+        noteHashes,
+        spender,
+        spenderApproval,
+    };
+
+    const { unformattedSignature } = signer.signTypedData(domain, schema, message, privateKey);
+    const signature = `0x${unformattedSignature.slice(0, 130)}`; // extract r, s, v (v is just 1 byte, 2 characters)
+    return signature;
+};
+
+/**
  * Construct EIP712 ECDSA signatures over an array of notes for use in calling confidentialTransfer()
  *
  * @method signNotesForConfidentialTransfer

--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -84,17 +84,18 @@ signer.signNoteForConfidentialApprove = (verifyingContract, noteHash, spender, s
  * @param {string} verifyingContract address of target contract
  * @param {string[]} noteHashes array of the keccak256 hashes of notes, for which approval is being granted or revoked
  * @param {string} spender address to which note control is being delegated
- * @param {bool} spenderApproval boolean determining whether the spender is being granted approval
+ * @param {bool} spenderApprovals array of booleans determining whether the spender is being granted or revoked approval
+ * for each note
  * @param {string} privateKey the private key of message signer
  * @returns {string} ECDSA signature parameters [r, s, v], formatted as 32-byte wide hex-strings
  */
-signer.signNotesForBatchConfidentialApprove = (verifyingContract, noteHashes, spender, spenderApproval, privateKey) => {
+signer.signNotesForBatchConfidentialApprove = (verifyingContract, noteHashes, spender, spenderApprovals, privateKey) => {
     const domain = signer.generateZKAssetDomainParams(verifyingContract);
     const schema = constants.eip712.MULTIPLE_NOTE_SIGNATURE;
     const message = {
         noteHashes,
         spender,
-        spenderApproval,
+        spenderApprovals,
     };
 
     const { unformattedSignature } = signer.signTypedData(domain, schema, message, privateKey);

--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -79,7 +79,7 @@ signer.signNoteForConfidentialApprove = (verifyingContract, noteHash, spender, s
  * ECSA signature is formatted as follows:
  * - `r` and `s` occupy 32 bytes
  * - `v` occupies 1 byte
- * 
+ *
  * @method signMultipleNotesForBatchConfidentialApprove
  * @param {string} verifyingContract address of target contract
  * @param {string[]} noteHashes array of the keccak256 hashes of notes, for which approval is being granted or revoked

--- a/packages/aztec.js/test/signer/index.js
+++ b/packages/aztec.js/test/signer/index.js
@@ -166,16 +166,17 @@ describe('Signer', () => {
             const { publicKey, privateKey } = secp256k1.generateAccount();
             const spender = randomHex(20);
             const verifyingContract = randomHex(20);
-            const spenderApproval = true;
+            const spenderApprovals = [true, true];
             const testNoteA = await note.create(publicKey, 10);
             const testNoteB = await note.create(publicKey, 30);
 
             const noteHashes = [testNoteA.noteHash, testNoteB.noteHash];
+
             const signature = signer.signNotesForBatchConfidentialApprove(
                 verifyingContract,
                 noteHashes,
                 spender,
-                spenderApproval,
+                spenderApprovals,
                 privateKey,
             );
 
@@ -189,7 +190,7 @@ describe('Signer', () => {
             const message = {
                 noteHashes,
                 spender,
-                spenderApproval,
+                spenderApprovals,
             };
 
             const { encodedTypedData } = signer.signTypedData(domain, schema, message, privateKey);

--- a/packages/aztec.js/test/signer/index.js
+++ b/packages/aztec.js/test/signer/index.js
@@ -162,6 +162,43 @@ describe('Signer', () => {
             expect(publicKeyRecover).to.equal(publicKey.slice(4));
         });
 
+        it('should recover publicKey from signNotesForBatchConfidentialApprove() sig params', async() => {
+            const { publicKey, privateKey } = secp256k1.generateAccount();
+            const spender = randomHex(20);
+            const verifyingContract = randomHex(20);
+            const spenderApproval = true;
+            const testNoteA = await note.create(publicKey, 10);
+            const testNoteB = await note.create(publicKey, 30);
+
+            const noteHashes = [testNoteA.noteHash, testNoteB.noteHash];
+            const signature = signer.signNotesForBatchConfidentialApprove(
+                verifyingContract,
+                noteHashes,
+                spender,
+                spenderApproval,
+                privateKey,
+            );
+
+            const r = Buffer.from(signature.slice(2, 66), 'hex');
+            const s = Buffer.from(signature.slice(66, 130), 'hex');
+            const v = parseInt(signature.slice(130, 132), 16);
+
+            // Reconstruct messageHash, to use in ecrecover
+            const domain = signer.generateZKAssetDomainParams(verifyingContract);
+            const schema = constants.eip712.MULTIPLE_NOTE_SIGNATURE;
+            const message = {
+                noteHashes,
+                spender,
+                spenderApproval,
+            };
+
+            const { encodedTypedData } = signer.signTypedData(domain, schema, message, privateKey);
+            const messageHash = Buffer.from(encodedTypedData.slice(2), 'hex');
+
+            const publicKeyRecover = ethUtil.ecrecover(messageHash, v, r, s).toString('hex');
+            expect(publicKeyRecover).to.equal(publicKey.slice(4));
+        });
+
         it('signNoteForConfidentialApprove() should produce same signature as MetaMask signing function', async () => {
             const aztecAccount = secp256k1.generateAccount();
             const spender = randomHex(20);

--- a/packages/aztec.js/test/signer/index.js
+++ b/packages/aztec.js/test/signer/index.js
@@ -162,7 +162,7 @@ describe('Signer', () => {
             expect(publicKeyRecover).to.equal(publicKey.slice(4));
         });
 
-        it('should recover publicKey from signNotesForBatchConfidentialApprove() sig params', async() => {
+        it('should recover publicKey from signNotesForBatchConfidentialApprove() sig params', async () => {
             const { publicKey, privateKey } = secp256k1.generateAccount();
             const spender = randomHex(20);
             const verifyingContract = randomHex(20);

--- a/packages/dev-utils/src/constants.js
+++ b/packages/dev-utils/src/constants.js
@@ -89,8 +89,8 @@ const JOIN_SPLIT_SIGNATURE_TYPE_HASH = '0xf671f176821d4c6f81e66f9704cdf2c5c12d34
 // keccak256 hash of "MultipleNoteSignature(bytes32[] noteHashes,address spender,bool[] spenderApprovals)"
 const MULTIPLE_NOTE_SIGNATURE_TYPE_HASH = '0x0aad58e28366c18fa0a3551d1215f4da4bd3c63c0376bb065dfd436f09e8d55a';
 
-// keccak256 hash of "NoteSignature(bytes32 noteHash,address spender,bool status)"
-const NOTE_SIGNATURE_TYPE_HASH = '0x9fe730639297761b7154c4543e5b6d06ca424c8b46480a40d3181296d5c35815';
+// keccak256 hash of "NoteSignature(bytes32 noteHash,address spender,bool spenderApproval)"
+const NOTE_SIGNATURE_TYPE_HASH = '0x18b99aa73a945da0bb8640ca1f178720091ea7d80be44da6ee02d9fd334623c2';
 
 constants.eip712 = {
     ACE_DOMAIN_PARAMS: {

--- a/packages/dev-utils/src/constants.js
+++ b/packages/dev-utils/src/constants.js
@@ -86,6 +86,9 @@ const EIP712_DOMAIN_SEPARATOR_SCHEMA_HASH = '0x91ab3d17e3a50a9d89e63fd30b92be7f5
 // keccak256 hash of "JoinSplitSignature(uint24 proof,bytes32 noteHash,uint256 challenge,address sender)"
 const JOIN_SPLIT_SIGNATURE_TYPE_HASH = '0xf671f176821d4c6f81e66f9704cdf2c5c12d34bd23561179229c9fe7a9e85462';
 
+// keccak256 hash of "MultipleNoteSignature(bytes32[] noteHashes,address spender,bool spenderApproval)"
+const MULTIPLE_NOTE_SIGNATURE_TYPE_HASH = '0x9321aa36de6bbc3c63259b7706768d5842ee27bdc3b1700106a436528b89732e';
+
 // keccak256 hash of "NoteSignature(bytes32 noteHash,address spender,bool status)"
 const NOTE_SIGNATURE_TYPE_HASH = '0x9fe730639297761b7154c4543e5b6d06ca424c8b46480a40d3181296d5c35815';
 
@@ -119,6 +122,18 @@ constants.eip712 = {
         primaryType: 'JoinSplitSignature',
     },
     JOIN_SPLIT_SIGNATURE_TYPE_HASH,
+    MULTIPLE_NOTE_SIGNATURE: {
+        types: {
+            MultipleNoteSignature: [
+                { name: 'noteHashes', type: 'bytes32[]' },
+                { name: 'spender', type: 'address' },
+                { name: 'spenderApproval', type: 'bool' },
+            ],
+            EIP712Domain: EIP712_DOMAIN,
+        },
+        primaryType: 'MultipleNoteSignature',
+    },
+    MULTIPLE_NOTE_SIGNATURE_TYPE_HASH,
     NOTE_SIGNATURE: {
         types: {
             NoteSignature: [

--- a/packages/dev-utils/src/constants.js
+++ b/packages/dev-utils/src/constants.js
@@ -86,8 +86,8 @@ const EIP712_DOMAIN_SEPARATOR_SCHEMA_HASH = '0x91ab3d17e3a50a9d89e63fd30b92be7f5
 // keccak256 hash of "JoinSplitSignature(uint24 proof,bytes32 noteHash,uint256 challenge,address sender)"
 const JOIN_SPLIT_SIGNATURE_TYPE_HASH = '0xf671f176821d4c6f81e66f9704cdf2c5c12d34bd23561179229c9fe7a9e85462';
 
-// keccak256 hash of "MultipleNoteSignature(bytes32[] noteHashes,address spender,bool spenderApproval)"
-const MULTIPLE_NOTE_SIGNATURE_TYPE_HASH = '0x9321aa36de6bbc3c63259b7706768d5842ee27bdc3b1700106a436528b89732e';
+// keccak256 hash of "MultipleNoteSignature(bytes32[] noteHashes,address spender,bool[] spenderApprovals)"
+const MULTIPLE_NOTE_SIGNATURE_TYPE_HASH = '0x0aad58e28366c18fa0a3551d1215f4da4bd3c63c0376bb065dfd436f09e8d55a';
 
 // keccak256 hash of "NoteSignature(bytes32 noteHash,address spender,bool status)"
 const NOTE_SIGNATURE_TYPE_HASH = '0x9fe730639297761b7154c4543e5b6d06ca424c8b46480a40d3181296d5c35815';
@@ -127,7 +127,7 @@ constants.eip712 = {
             MultipleNoteSignature: [
                 { name: 'noteHashes', type: 'bytes32[]' },
                 { name: 'spender', type: 'address' },
-                { name: 'spenderApproval', type: 'bool' },
+                { name: 'spenderApprovals', type: 'bool[]' },
             ],
             EIP712Domain: EIP712_DOMAIN,
         },

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
@@ -36,7 +36,7 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
         "NoteSignature(",
             "bytes32 noteHash,",
             "address spender,",
-            "bool[] spenderApprovals",
+            "bool spenderApproval",
         ")"
     ));
     

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
@@ -28,7 +28,7 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
         "MultipleNoteSignature(",
             "bytes32[] noteHashes,",
             "address spender,",
-            "bool spenderApproval",
+            "bool[] spenderApprovals",
         ")"
     ));
 
@@ -36,7 +36,7 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
         "NoteSignature(",
             "bytes32 noteHash,",
             "address spender,",
-            "bool spenderApproval",
+            "bool[] spenderApprovals",
         ")"
     ));
     
@@ -166,14 +166,14 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
      *
      * @param _noteHashes - array of the keccak256 hashes of notes, due to be spent
      * @param _spender - address being approved to spend the notes
-     * @param _spenderApproval - defines whether the _spender address is being approved to spend the
-     * note, or if permission is being revoked. True if approved, false if not approved
+     * @param _spenderApprovals - array of approvals, defining whether the _spender being approved or revoked permission
+     * to spend the relevant note. True if approval granted, false if revoked
      * @param _batchSignature - ECDSA signature over the notes, approving them to be spent
      */
     function batchConfidentialApprove(
         bytes32[] memory _noteHashes,
         address _spender,
-        bool _spenderApproval,
+        bool[] memory _spenderApprovals,
         bytes memory _batchSignature
     ) public {
 
@@ -186,7 +186,7 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
             MULTIPLE_NOTE_SIGNATURE_TYPEHASH,
             keccak256(abi.encode(_noteHashes)),
             _spender,
-            _spenderApproval
+            keccak256(abi.encode(_spenderApprovals))
         ));
 
         bytes32 msgHash = hashEIP712Message(_hashStruct);
@@ -200,7 +200,7 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
             ( uint8 status, , , address noteOwner ) = ace.getNote(address(this), _noteHashes[i]);
             require(status == 1, "only unspent notes can be approved");
             require(noteOwner == signer, "the note owner did not sign this message");
-            confidentialApproved[_noteHashes[i]][_spender] = _spenderApproval;
+            confidentialApproved[_noteHashes[i]][_spender] = _spenderApprovals[i];
         }
     }
 

--- a/packages/protocol/contracts/test/ERC1724/ZkAssetOwnableTest.sol
+++ b/packages/protocol/contracts/test/ERC1724/ZkAssetOwnableTest.sol
@@ -28,9 +28,9 @@ contract ZkAssetOwnableTest {
     function callBatchConfidentialApprove(
         bytes32[] memory _noteHashes,
         address _spender,
-        bool _spenderApproval,
+        bool[] memory _spenderApprovals,
         bytes memory _batchSignature
     ) public {
-        zkAssetOwnable.batchConfidentialApprove(_noteHashes, _spender, _spenderApproval, _batchSignature);
+        zkAssetOwnable.batchConfidentialApprove(_noteHashes, _spender, _spenderApprovals, _batchSignature);
     }
 }

--- a/packages/protocol/contracts/test/ERC1724/ZkAssetOwnableTest.sol
+++ b/packages/protocol/contracts/test/ERC1724/ZkAssetOwnableTest.sol
@@ -24,4 +24,13 @@ contract ZkAssetOwnableTest {
         // throws if not approval had not been given before
         zkAssetOwnable.confidentialTransferFrom(_proof, _proofOutput);
     }
+
+    function callBatchConfidentialApprove(
+        bytes32[] memory _noteHashes,
+        address _spender,
+        bool _spenderApproval,
+        bytes memory _batchSignature
+    ) public {
+        zkAssetOwnable.batchConfidentialApprove(_noteHashes, _spender, _spenderApproval, _batchSignature);
+    }
 }

--- a/packages/protocol/test/ERC1724/ZkAssetOwnable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetOwnable.js
@@ -198,7 +198,7 @@ contract('ZkAssetOwnable', (accounts) => {
             expect(result.status.toNumber()).to.equal(constants.statuses.NOTE_SPENT);
         });
 
-        it('should delegate a contract to update a note registry with kPublic = 0', async () => {
+        it('should delegate, using confidentialApprove(), a contract to update a note registry with kPublic = 0', async () => {
             const depositOutputNoteValues = [10, 20];
             const depositPublicValue = -30;
 
@@ -293,6 +293,64 @@ contract('ZkAssetOwnable', (accounts) => {
             await zkAssetOwnable.confidentialApprove(testNote.noteHash, spenderAddress, spenderApproval, revokeApprovalSignature);
             const loggedRevokedStatus = await zkAssetOwnable.confidentialApproved.call(testNote.noteHash, spenderAddress);
             expect(loggedRevokedStatus).to.equal(false);
+        });
+
+        it.only('should delegate spending control of multiple notes, using batchConfidentialApprove()', async () => {
+            const { publicKey, privateKey } = secp256k1.generateAccount();
+            const testNoteA = await note.create(publicKey, 10);
+            const testNoteB = await note.create(publicKey, 40);
+
+            // Create some notes in the assets note registry
+            const depositInputNotes = [];
+            const depositOutputNotes = [testNoteA, testNoteB];
+            const depositPublicValue = -50;
+
+            const depositProof = new JoinSplitProof(
+                depositInputNotes,
+                depositOutputNotes,
+                sender,
+                depositPublicValue,
+                publicOwner,
+            );
+            const signatures = [];
+            const depositData = depositProof.encodeABI(zkAssetOwnable.address);
+
+            await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, { from: sender });
+
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, signatures, {
+                from: sender,
+            });
+
+            const transferInputNotes = depositOutputNotes;
+            const transferOutputNotes = [await note.create(publicKey, 50)];
+            const withdrawalPublicValue = 0;
+
+            const transferProof = new JoinSplitProof(
+                transferInputNotes,
+                transferOutputNotes,
+                sender,
+                withdrawalPublicValue,
+                publicOwner,
+            );
+            const transferData = transferProof.encodeABI(zkAssetOwnableTest.address);
+
+            await zkAssetOwnableTest.callValidateProof(JOIN_SPLIT_PROOF, transferData);
+
+            const spenderApproval = true;
+            const noteHashes = [testNoteA.noteHash, testNoteB.noteHash];
+            const spender = zkAssetOwnableTest.address;
+
+            const batchSignature = signer.signNotesForBatchConfidentialApprove(
+                zkAssetOwnable.address,
+                noteHashes,
+                spender,
+                spenderApproval,
+                privateKey,
+            );
+
+            await zkAssetOwnableTest.callBatchConfidentialApprove(noteHashes, spender, spenderApproval, batchSignature);
+            const { receipt } = await zkAssetOwnableTest.callConfidentialTransferFrom(JOIN_SPLIT_PROOF, transferProof.eth.output);
+            expect(receipt.status).to.equal(true);
         });
     });
 

--- a/packages/protocol/test/ERC1724/ZkAssetOwnable.js
+++ b/packages/protocol/test/ERC1724/ZkAssetOwnable.js
@@ -295,7 +295,7 @@ contract('ZkAssetOwnable', (accounts) => {
             expect(loggedRevokedStatus).to.equal(false);
         });
 
-        it.only('should delegate spending control of multiple notes, using batchConfidentialApprove()', async () => {
+        it('should delegate spending control of multiple notes, using batchConfidentialApprove()', async () => {
             const { publicKey, privateKey } = secp256k1.generateAccount();
             const testNoteA = await note.create(publicKey, 10);
             const testNoteB = await note.create(publicKey, 40);
@@ -336,7 +336,7 @@ contract('ZkAssetOwnable', (accounts) => {
 
             await zkAssetOwnableTest.callValidateProof(JOIN_SPLIT_PROOF, transferData);
 
-            const spenderApproval = true;
+            const spenderApprovals = [true, true];
             const noteHashes = [testNoteA.noteHash, testNoteB.noteHash];
             const spender = zkAssetOwnableTest.address;
 
@@ -344,13 +344,75 @@ contract('ZkAssetOwnable', (accounts) => {
                 zkAssetOwnable.address,
                 noteHashes,
                 spender,
-                spenderApproval,
+                spenderApprovals,
                 privateKey,
             );
 
-            await zkAssetOwnableTest.callBatchConfidentialApprove(noteHashes, spender, spenderApproval, batchSignature);
+            await zkAssetOwnableTest.callBatchConfidentialApprove(noteHashes, spender, spenderApprovals, batchSignature);
             const { receipt } = await zkAssetOwnableTest.callConfidentialTransferFrom(JOIN_SPLIT_PROOF, transferProof.eth.output);
             expect(receipt.status).to.equal(true);
+        });
+
+        it('should seletively approve and revoke spending control of multiple notes, using batchConfidentialApprove()', async () => {
+            const { publicKey, privateKey } = secp256k1.generateAccount();
+            const testNoteA = await note.create(publicKey, 10);
+            const testNoteB = await note.create(publicKey, 40);
+
+            // Create some notes in the assets note registry
+            const depositInputNotes = [];
+            const depositOutputNotes = [testNoteA, testNoteB];
+            const depositPublicValue = -50;
+
+            const depositProof = new JoinSplitProof(
+                depositInputNotes,
+                depositOutputNotes,
+                sender,
+                depositPublicValue,
+                publicOwner,
+            );
+            const signatures = [];
+            const depositData = depositProof.encodeABI(zkAssetOwnable.address);
+
+            await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, { from: sender });
+
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, signatures, {
+                from: sender,
+            });
+
+            const transferInputNotes = depositOutputNotes;
+            const transferOutputNotes = [await note.create(publicKey, 50)];
+            const withdrawalPublicValue = 0;
+
+            const transferProof = new JoinSplitProof(
+                transferInputNotes,
+                transferOutputNotes,
+                sender,
+                withdrawalPublicValue,
+                publicOwner,
+            );
+            const transferData = transferProof.encodeABI(zkAssetOwnableTest.address);
+
+            await zkAssetOwnableTest.callValidateProof(JOIN_SPLIT_PROOF, transferData);
+
+            const spenderApprovals = [true, false];
+            const noteHashes = [testNoteA.noteHash, testNoteB.noteHash];
+            const spender = zkAssetOwnableTest.address;
+
+            const batchSignature = signer.signNotesForBatchConfidentialApprove(
+                zkAssetOwnable.address,
+                noteHashes,
+                spender,
+                spenderApprovals,
+                privateKey,
+            );
+
+            await zkAssetOwnableTest.callBatchConfidentialApprove(noteHashes, spender, spenderApprovals, batchSignature);
+
+            const loggedApprovalStatusA = await zkAssetOwnable.confidentialApproved.call(testNoteA.noteHash, spender);
+            expect(loggedApprovalStatusA).to.equal(true);
+
+            const loggedApprovalStatusB = await zkAssetOwnable.confidentialApproved.call(testNoteB.noteHash, spender);
+            expect(loggedApprovalStatusB).to.equal(false);
         });
     });
 
@@ -644,6 +706,54 @@ contract('ZkAssetOwnable', (accounts) => {
             await truffleAssert.reverts(
                 zkAssetOwnable.confidentialApprove(testNote.noteHash, spenderAddress, spenderApproval, approvalSignature),
                 'signature has already been used',
+            );
+        });
+
+        it('should fail to perform confidentialTransferFrom() if batchConfidentialApprove() not previously called', async () => {
+            const { publicKey } = secp256k1.generateAccount();
+            const testNoteA = await note.create(publicKey, 10);
+            const testNoteB = await note.create(publicKey, 40);
+
+            // Create some notes in the assets note registry
+            const depositInputNotes = [];
+            const depositOutputNotes = [testNoteA, testNoteB];
+            const depositPublicValue = -50;
+
+            const depositProof = new JoinSplitProof(
+                depositInputNotes,
+                depositOutputNotes,
+                sender,
+                depositPublicValue,
+                publicOwner,
+            );
+            const signatures = [];
+            const depositData = depositProof.encodeABI(zkAssetOwnable.address);
+
+            await ace.publicApprove(zkAssetOwnable.address, depositProof.hash, depositPublicValue, { from: sender });
+
+            await zkAssetOwnable.methods['confidentialTransfer(bytes,bytes)'](depositData, signatures, {
+                from: sender,
+            });
+
+            const transferInputNotes = depositOutputNotes;
+            const transferOutputNotes = [await note.create(publicKey, 50)];
+            const withdrawalPublicValue = 0;
+
+            const transferProof = new JoinSplitProof(
+                transferInputNotes,
+                transferOutputNotes,
+                sender,
+                withdrawalPublicValue,
+                publicOwner,
+            );
+            const transferData = transferProof.encodeABI(zkAssetOwnableTest.address);
+
+            await zkAssetOwnableTest.callValidateProof(JOIN_SPLIT_PROOF, transferData);
+
+            // batchConfidentialApprove() not called
+            await truffleAssert.reverts(
+                zkAssetOwnableTest.callConfidentialTransferFrom(JOIN_SPLIT_PROOF, transferProof.eth.output),
+                'sender does not have approval to spend input note',
             );
         });
     });


### PR DESCRIPTION
## Summary
This PR adds a `batchConfidentialApprove()` method to the `ZkAssetBase.sol` contract, to allow multiple notes to be approved to be spent by a third party address in one function call. 

This improves the UX for users.
<!--- Summarise your changes -->

## Description

### aztec.js
A new EIP712 signing function has been added to the `signer` module:
```
signNotesForBatchConfidentialApprove(verifyingContract, noteHashes, spender, spenderApprovals, privateKey)
```

`noteHashes` is an array of the hashes of all notes being simultaneously approved or revoked. `spenderApprovals` is an array of booleans representing whether each note in the corresponding index position in the `noteHashes` array is having permission approved or revoked. 

### protocol
The `ZkAssetBase.sol` contract has a new method `batchConfidentialApprove()`. This validates the signature generated by the new signing function, and will update the mapping `confidentialApproved` with the resulting permissioning. 

This function includes signature replay protection, checks that the notes in question are valid and that the signature is valid - i.e. that the owner of the notes in question is responsible for the supplied signature. 

### dev-utils
The associated EIP712 signature schemas and hashes have been added.

<!--- Describe your changes in detail -->

## Testing instructions
Various tests confirming the `aztec.js` signing function and contract signature validation have been added. 

<!--- Please describe how reviewers can test your changes -->

## Types of changes
- New feature: `batchConfidentialApprove()`
