### PR TITLE
Fix `mint()` error message

### DIFF
--- a/packages/protocol/contracts/ACE/noteRegistry/epochs/201907/adjustable/BehaviourAdjustable201907.sol
+++ b/packages/protocol/contracts/ACE/noteRegistry/epochs/201907/adjustable/BehaviourAdjustable201907.sol
@@ -51,7 +51,7 @@ contract BehaviourAdjustable201907 is Behaviour201907 {
         ,) = _proofOutputs.get(1).extractProofOutput();
 
         (, bytes32 oldTotalNoteHash, ) = oldTotal.get(0).extractNote();
-        require(oldTotalNoteHash == registry.confidentialTotalMinted, "provided total burned note does not match");
+        require(oldTotalNoteHash == registry.confidentialTotalMinted, "provided total minted note does not match");
         (, bytes32 newTotalNoteHash, ) = newTotal.get(0).extractNote();
         setConfidentialTotalMinted(newTotalNoteHash);
 


### PR DESCRIPTION
## Summary
This PR fixes an error message in the `mint()` function of `BehaviourAdjustable201907.sol`. The error message referred to a total burned note, rather than a total minted note. 

<!--- Summarise your changes -->

## Description

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
