### PR TITLE
Fix validated proofs mapping

### DIFF
--- a/packages/protocol/contracts/ACE/noteRegistry/NoteRegistryManager.sol
+++ b/packages/protocol/contracts/ACE/noteRegistry/NoteRegistryManager.sol
@@ -363,12 +363,14 @@ contract NoteRegistryManager is IAZTEC, Ownable {
         NoteRegistry memory registry = registries[msg.sender];
         require(address(registry.behaviour) != address(0x0), "note registry does not exist");
         bytes32 proofHash = keccak256(_proofOutput);
+        bytes32 validatedProofHash = keccak256(abi.encode(proofHash, _proof, msg.sender));
+
         require(
             validateProofByHash(_proof, proofHash, _proofSender) == true,
             "ACE has not validated a matching proof"
         );
         // clear record of valid proof - stops re-entrancy attacks and saves some gas
-        validatedProofs[proofHash] = false;
+        validatedProofs[validatedProofHash] = false;
 
         (
             address publicOwner,

--- a/packages/protocol/test/ACE/ACEJoinSplitFluid.js
+++ b/packages/protocol/test/ACE/ACEJoinSplitFluid.js
@@ -13,6 +13,8 @@ const { BURN_PROOF, JOIN_SPLIT_PROOF, MINT_PROOF } = proofs;
 
 // ### Artifacts
 const ACE = artifacts.require('./ACE');
+const AdjustableFactory = artifacts.require('./noteRegistry/epochs/201907/adjustable/FactoryAdjustable201907');
+const BaseFactory = artifacts.require('./noteRegistry/epochs/201907/base/FactoryBase201907');
 const Dividend = artifacts.require('./Dividend');
 const DividendInterface = artifacts.require('./DividendInterface');
 const ERC20Mintable = artifacts.require('./ERC20Mintable');
@@ -22,8 +24,6 @@ const JoinSplitFluid = artifacts.require('./JoinSplitFluid');
 const JoinSplitFluidInterface = artifacts.require('./JoinSplitFluidInterface');
 const Swap = artifacts.require('./Swap');
 const SwapInterface = artifacts.require('./SwapInterface');
-const AdjustableFactory = artifacts.require('./noteRegistry/epochs/201907/adjustable/FactoryAdjustable201907');
-const BaseFactory = artifacts.require('./noteRegistry/epochs/201907/base/FactoryBase201907');
 
 const { generateFactoryId } = require('../helpers/Factory');
 


### PR DESCRIPTION
## Summary
This PR fixes a bug in `NoteRegistryManager.sol`, which meant that a previously validated proof was not being removed from the `validatedProofs` mapping once used to update state in `ace.updateNoteRegistry()`. 

This was due to an incorrect key being calculated.
<!--- Summarise your changes -->

## Description
The `validatedProofs` mapping is used to keep track of which state affecting (i.e. BALANCED proofs) proofs have previously been used, in order to prevent replay based attacks. 

When the mapping is set to `true` upon successfull validation of a proof, the key is calculated as:
```
keccak256(abi.encode(proofHash, _proof, msg.sender))
```

However, when the mapping is set to `false` in `updateNoteRegistry()` - once the state change is effected - the mapping is calculated as:

```
proofHash
```

This PR makes the key used to set the mapping to `false`, the same as that to set the mapping to `true`, in order to correctly clear the mapping.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
