### PR TITLE
Prevent 0x0 address in multisig replaceOwner()

### DIFF
--- a/packages/protocol/contracts/MultiSig/MultiSigWallet.sol
+++ b/packages/protocol/contracts/MultiSig/MultiSigWallet.sol
@@ -157,6 +157,7 @@ contract MultiSigWallet {
     /// @param newOwner Address of new owner.
     function replaceOwner(address owner, address newOwner)
         public
+        notNull(newOwner)
         onlyWallet
         ownerExists(owner)
         ownerDoesNotExist(newOwner)


### PR DESCRIPTION
## Summary
This PR prevents the possibility of incorrectly replacing an owner of the `MultiSigWallet.sol` with the `0x0` address. 

<!--- Summarise your changes -->

## Description
The `notNull()` modifer has been added to the `MultisigWallet.replaceOwner()` method to prevent the `0x0` potentially being assigned as one of the owners. 

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
