### PR TITLE
Fix ACE withdraw function

### DIFF
--- a/packages/protocol/contracts/ACE/ACE.sol
+++ b/packages/protocol/contracts/ACE/ACE.sol
@@ -418,7 +418,7 @@ contract ACE is IAZTEC, Ownable, NoteRegistryManager, Chargeable {
     {
         require(_destination != address(0x0), "can not withdraw to 0x0 address");
         require(_amount <= address(this).balance, "can not withdraw more than balance");
-        _destination.transfer(address(this).balance);
+        _destination.transfer(_amount);
         return true;
     }
 }

--- a/packages/protocol/contracts/ACE/ACE.sol
+++ b/packages/protocol/contracts/ACE/ACE.sol
@@ -416,7 +416,6 @@ contract ACE is IAZTEC, Ownable, NoteRegistryManager, Chargeable {
         public
         onlyOwner
     {
-        require(_multiplier <= 2000, "can not set the multiplier to be above 2x");
         gasMultiplier = _multiplier;
         emit SetGasMultiplier(_multiplier);
     }

--- a/packages/protocol/contracts/ACE/ACE.sol
+++ b/packages/protocol/contracts/ACE/ACE.sol
@@ -394,6 +394,12 @@ contract ACE is IAZTEC, Ownable, NoteRegistryManager, Chargeable {
         }
     }
 
+    /**
+    * @dev Set the gas cost for a particular proof
+    * @param _proofId unique identifier for a proof, used to specify which proof
+    * the _gasCost is being set for
+    * @param _gasCost gas cost associated with the proof specified by _proofId
+    */
     function setProofGasCost(uint24 _proofId, uint256 _gasCost)
         public
         onlyOwner
@@ -402,6 +408,10 @@ contract ACE is IAZTEC, Ownable, NoteRegistryManager, Chargeable {
         emit SetGasCostForProof(_proofId, _gasCost);
     }
 
+    /**
+    * @dev Set the gas multplier
+    * @param _multiplier multiplier applied to the gas fee charged for the transaction
+    */
     function setGasMultiplier(uint256 _multiplier)
         public
         onlyOwner
@@ -411,6 +421,11 @@ contract ACE is IAZTEC, Ownable, NoteRegistryManager, Chargeable {
         emit SetGasMultiplier(_multiplier);
     }
 
+    /**
+    * @dev Withdraw funds from the ACE contract to a specified address
+    * @param _destination Ethereum address to which funds are being withdrawn
+    * @param _amount quantity of funds to be transferred
+    */
     function withdraw(address payable _destination, uint256 _amount)
         public
         onlyOwner

--- a/packages/protocol/contracts/ACE/Chargeable.sol
+++ b/packages/protocol/contracts/ACE/Chargeable.sol
@@ -2,6 +2,13 @@ pragma solidity >=0.5.0 <0.6.0;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
+/**
+* @title Chargeable
+* @author AZTEC
+* @dev Allows gas fees for AZTEC proofs to be set
+*
+* Copyright Spilsbury Holdings Ltd 2019. All rights reserved.
+*/
 contract Chargeable {
     using SafeMath for uint256;
 
@@ -14,6 +21,9 @@ contract Chargeable {
     uint256 public gasMultiplier = 0;
     uint256 public constant multiplierScalingFactor = 1000;
 
+    /**
+    * @dev Calculate and emit an event with the expected AZTEC fee
+    */
     modifier fee(uint24 _proofId) {
         uint256 gasFee = getFeeForProof(_proofId);
         uint256 feeExpected = gasFee.mul(uint256(tx.gasprice));
@@ -22,6 +32,12 @@ contract Chargeable {
         _;
     }
 
+    /**
+    * @dev Calculate the gas fee for a particular proof, specified by _proofId
+    * @param _proofId unique identifier used to specify the proof for which the 
+    * gas fee is being calculated
+    * @return the gas fee for using the specified AZTEC proof
+    */
     function getFeeForProof(uint24 _proofId) public view returns (uint256 gasFee) {
         uint256 gasCost = proofGasCosts[_proofId];
         gasFee = gasCost.mul(gasMultiplier).div(multiplierScalingFactor);


### PR DESCRIPTION
## Summary
This PR fixes a bug in the `ace.withdraw()` function whereby the withdraw withdrew the balance of the `ACE` contract rather than the specified `_amount` input to the function. 

It also documents the various functions and contracts that have been added in this work and removes a multiplier limit. 
<!--- Summarise your changes -->

## Description

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
