### PR TITLE
Remove metadata from DestroyNote event

### DIFF
--- a/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
@@ -393,8 +393,8 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
     */
     function logInputNotes(bytes memory inputNotes) internal {
         for (uint i = 0; i < inputNotes.getLength(); i += 1) {
-            (address noteOwner, bytes32 noteHash, bytes memory metadata) = inputNotes.get(i).extractNote();
-            emit DestroyNote(noteOwner, noteHash, metadata);
+            (address noteOwner, bytes32 noteHash, ) = inputNotes.get(i).extractNote();
+            emit DestroyNote(noteOwner, noteHash);
         }
     }
 

--- a/packages/protocol/contracts/interfaces/IZkAsset.sol
+++ b/packages/protocol/contracts/interfaces/IZkAsset.sol
@@ -17,7 +17,7 @@ contract IZkAsset {
     );
     event CreateNoteRegistry(uint256 noteRegistryId);
     event CreateNote(address indexed owner, bytes32 indexed noteHash, bytes metadata);
-    event DestroyNote(address indexed owner, bytes32 indexed noteHash, bytes metadata);
+    event DestroyNote(address indexed owner, bytes32 indexed noteHash);
     event ConvertTokens(address indexed owner, uint256 value);
     event RedeemTokens(address indexed owner, uint256 value);
     event UpdateNoteMetaData(address indexed owner, bytes32 indexed noteHash, bytes metadata);


### PR DESCRIPTION
## Summary
This PR removes the `metadata` parameter from the `DestroyNote` event. 

<!--- Summarise your changes -->

## Description
The most up to date version of the `metadata` of a note will be available from the latest `UpdateNoteMetaData` event. 

The `DestroyNote` is used soley to signal that a note has been destroyed, rather than also convey a `metadata` update. 

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
