### PR TITLE
Deploy ZkAssetAdjustable

### DIFF
--- a/packages/contract-artifacts/src/index.js
+++ b/packages/contract-artifacts/src/index.js
@@ -32,6 +32,7 @@ const Swap = require('../artifacts/Swap');
 const SwapABIEncoder = require('../artifacts/SwapABIEncoder');
 const SwapInterface = require('../artifacts/SwapInterface');
 const ZkAsset = require('../artifacts/ZkAsset');
+const ZkAssetAdjustable = require('../artifacts/ZkAssetAdjustable');
 const ZkAssetBase = require('../artifacts/ZkAssetBase');
 const ZkAssetBurnable = require('../artifacts/ZkAssetBurnable');
 const ZkAssetBurnableBase = requie('../artifacts/ZkAssetBurnableBase');
@@ -75,6 +76,7 @@ module.exports = {
     SwapABIEncoder,
     SwapInterface,
     ZkAsset,
+    ZkAssetAdjustable,
     ZkAssetBase,
     ZkAssetBurnable,
     ZkAssetBurnableBase,

--- a/packages/monorepo-scripts/addresses/update.js
+++ b/packages/monorepo-scripts/addresses/update.js
@@ -22,6 +22,7 @@ const deployedContracts = [
     'PublicRange',
     'Swap',
     'ZkAsset',
+    'ZkAssetAdjustable',
 ];
 
 const rinkebyAddresses = {};


### PR DESCRIPTION
## Summary
This PR adds the `ZkAssetAdjustable.sol` into the deployment scripts, so that the `contract-artifacts` and `contract-addresses` packages include the artifact and address of this contract. It is needed for the integration test suite.

## Types of changes
<!-- * New feature (non-breaking change which adds functionality) -->
Add the `ZkAssetAdjustable` into the deployment scripts

