### PR TITLE
Make signing over arrays compatible with MetaMask

### DIFF
--- a/packages/aztec.js/package.json
+++ b/packages/aztec.js/package.json
@@ -16,6 +16,7 @@
     "bn.js": "^4.11.8",
     "cross-fetch": "^3.0.2",
     "enumify": "^1.0.4",
+    "eth-sig-util": "^2.5.0",
     "ethereumjs-abi": "^0.6.7",
     "ethereumjs-util": "^6.1.0",
     "web3-utils": "1.2.1"
@@ -34,7 +35,6 @@
     "eslint-config-prettier": "^6.0.0",
     "eslint-loader": "^3.0.0",
     "eslint-plugin-import": "^2.16.0",
-    "eth-sig-util": "^2.3.0",
     "jsdoc": "^3.5.5",
     "mocha": "^6.0.2",
     "nyc": "^14.1.1",

--- a/packages/aztec.js/test/signer/index.js
+++ b/packages/aztec.js/test/signer/index.js
@@ -252,7 +252,7 @@ describe('Signer', () => {
         it('signNotesForBatchConfidentialApprove() should produce same signature as MetaMask signing function', async () => {
             const aztecAccount = secp256k1.generateAccount();
             const spender = randomHex(20);
-            const spenderApprovals = [ true, true ];
+            const spenderApprovals = [true, true];
             const verifyingContract = randomHex(20);
             const testNoteValue = 10;
             const testNoteA = await note.create(aztecAccount.publicKey, testNoteValue);
@@ -286,7 +286,6 @@ describe('Signer', () => {
                 },
             };
 
-
             const aztecSignature = signer.signNotesForBatchConfidentialApprove(
                 verifyingContract,
                 noteHashes,
@@ -294,7 +293,6 @@ describe('Signer', () => {
                 spenderApprovals,
                 aztecAccount.privateKey,
             );
-
 
             // eth-sig-util is the MetaMask signing package
             const metaMaskSignature = ethSigUtil.signTypedData_v4(Buffer.from(aztecAccount.privateKey.slice(2), 'hex'), {

--- a/packages/aztec.js/test/signer/index.js
+++ b/packages/aztec.js/test/signer/index.js
@@ -243,9 +243,64 @@ describe('Signer', () => {
             );
 
             // eth-sig-util is the MetaMask signing package
-            const metaMaskSignature = ethSigUtil.signTypedData(Buffer.from(aztecAccount.privateKey.slice(2), 'hex'), {
+            const metaMaskSignature = ethSigUtil.signTypedData_v4(Buffer.from(aztecAccount.privateKey.slice(2), 'hex'), {
                 data: metaMaskTypedData,
             });
+            expect(aztecSignature).to.equal(metaMaskSignature);
+        });
+
+        it('signNotesForBatchConfidentialApprove() should produce same signature as MetaMask signing function', async () => {
+            const aztecAccount = secp256k1.generateAccount();
+            const spender = randomHex(20);
+            const spenderApprovals = [ true, true ];
+            const verifyingContract = randomHex(20);
+            const testNoteValue = 10;
+            const testNoteA = await note.create(aztecAccount.publicKey, testNoteValue);
+            const testNoteB = await note.create(aztecAccount.publicKey, testNoteValue);
+
+            const noteHashes = [testNoteA.noteHash, testNoteB.noteHash];
+
+            const metaMaskTypedData = {
+                domain: {
+                    name: 'ZK_ASSET',
+                    version: '1',
+                    verifyingContract,
+                },
+                types: {
+                    MultipleNoteSignature: [
+                        { name: 'noteHashes', type: 'bytes32[]' },
+                        { name: 'spender', type: 'address' },
+                        { name: 'spenderApprovals', type: 'bool[]' },
+                    ],
+                    EIP712Domain: [
+                        { name: 'name', type: 'string' },
+                        { name: 'version', type: 'string' },
+                        { name: 'verifyingContract', type: 'address' },
+                    ],
+                },
+                primaryType: 'MultipleNoteSignature',
+                message: {
+                    noteHashes,
+                    spender,
+                    spenderApprovals,
+                },
+            };
+
+
+            const aztecSignature = signer.signNotesForBatchConfidentialApprove(
+                verifyingContract,
+                noteHashes,
+                spender,
+                spenderApprovals,
+                aztecAccount.privateKey,
+            );
+
+
+            // eth-sig-util is the MetaMask signing package
+            const metaMaskSignature = ethSigUtil.signTypedData_v4(Buffer.from(aztecAccount.privateKey.slice(2), 'hex'), {
+                data: metaMaskTypedData,
+            });
+
             expect(aztecSignature).to.equal(metaMaskSignature);
         });
     });

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
@@ -184,9 +184,9 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
 
         bytes32 _hashStruct = keccak256(abi.encode(
             MULTIPLE_NOTE_SIGNATURE_TYPEHASH,
-            keccak256(abi.encode(_noteHashes)),
+            keccak256(abi.encodePacked(_noteHashes)),
             _spender,
-            keccak256(abi.encode(_spenderApprovals))
+            keccak256(abi.encodePacked(_spenderApprovals))
         ));
 
         bytes32 msgHash = hashEIP712Message(_hashStruct);

--- a/packages/typed-data/package.json
+++ b/packages/typed-data/package.json
@@ -19,6 +19,7 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-import": "^2.16.0",
+    "eth-sig-util": "^2.5.2",
     "mocha": "^6.0.2",
     "shx": "^0.3.2"
   },

--- a/packages/typed-data/src/index.js
+++ b/packages/typed-data/src/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module to construct ECDSA messages for structured data,
  * following the [EIP712]{@link https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md} standard
@@ -38,14 +37,14 @@ signer.encodeMessageData = function encodeMessageData(types, primaryType, messag
         if (type.includes('[')) {
             const arrayRawEncoding = signer.encodeArray(type, message[name]);
             return `${acc}${arrayRawEncoding}`;
-
         }
         return `${acc}${AbiCoder.encodeParameters([type], [message[name]]).slice(2)}`;
     }, sliceKeccak256(signer.encodeStruct(primaryType, types)));
 };
 
 /**
- * Encode an array, according to the method used by MetaMask
+ * Encode an array, according to the method used by MetaMask. Code adapted from MetaMask's
+ * encodeData() method in the eth-sig-util module - https://github.com/MetaMask/eth-sig-util/blob/master/index.js
  *
  * @method encodeArray
  * @param {String} type - type of the data structure to be encoded
@@ -58,10 +57,7 @@ signer.encodeArray = function encodeArray(type, data) {
     const arrayElementTypes = typeValuePairs.map(([individualType]) => individualType);
     const arrayValueTypes = typeValuePairs.map(([, value]) => value);
 
-    return (ethUtil.sha3(ethAbi.rawEncode(
-        arrayElementTypes,
-        arrayValueTypes,
-    ))).toString('hex');
+    return ethUtil.sha3(ethAbi.rawEncode(arrayElementTypes, arrayValueTypes)).toString('hex');
 };
 
 /**

--- a/packages/typed-data/src/index.js
+++ b/packages/typed-data/src/index.js
@@ -1,10 +1,12 @@
+
 /**
  * Module to construct ECDSA messages for structured data,
  * following the [EIP712]{@link https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md} standard
  *
  * @module sign.signer
  */
-
+const ethAbi = require('ethereumjs-abi');
+const ethUtil = require('ethereumjs-util');
 const AbiCoder = require('web3-eth-abi');
 const { keccak256 } = require('web3-utils');
 
@@ -34,10 +36,32 @@ signer.encodeMessageData = function encodeMessageData(types, primaryType, messag
             return `${acc}${sliceKeccak256(message[name])}`;
         }
         if (type.includes('[')) {
-            return `${acc}${sliceKeccak256(AbiCoder.encodeParameter(type, message[name]))}`;
+            const arrayRawEncoding = signer.encodeArray(type, message[name]);
+            return `${acc}${arrayRawEncoding}`;
+
         }
         return `${acc}${AbiCoder.encodeParameters([type], [message[name]]).slice(2)}`;
     }, sliceKeccak256(signer.encodeStruct(primaryType, types)));
+};
+
+/**
+ * Encode an array, according to the method used by MetaMask
+ *
+ * @method encodeArray
+ * @param {String} type - type of the data structure to be encoded
+ * @param {Array} data - array data to be encoded
+ */
+signer.encodeArray = function encodeArray(type, data) {
+    const arrayElementAtomicType = type.slice(0, type.lastIndexOf('['));
+    const typeValuePairs = data.map((item) => [arrayElementAtomicType, item]);
+
+    const arrayElementTypes = typeValuePairs.map(([individualType]) => individualType);
+    const arrayValueTypes = typeValuePairs.map(([, value]) => value);
+
+    return (ethUtil.sha3(ethAbi.rawEncode(
+        arrayElementTypes,
+        arrayValueTypes,
+    ))).toString('hex');
 };
 
 /**

--- a/packages/typed-data/test/signer.js
+++ b/packages/typed-data/test/signer.js
@@ -33,15 +33,12 @@ describe('Signer', () => {
 
         arrayData = {
             types: {
-                Foo: [
-                    { name: 'bytes32Array', type: 'bytes32[]' },
-                    { name: 'boolArray', type: 'bool[]' },
-                ],
+                Foo: [{ name: 'bytes32Array', type: 'bytes32[]' }, { name: 'boolArray', type: 'bool[]' }],
             },
             primaryType: 'Foo',
             message: {
                 bytes32Array: [padRight('0xe43', 64), padRight('0xa3d2', 64)],
-                boolArray: [ true, true ],
+                boolArray: [true, true],
             },
         };
 
@@ -72,17 +69,14 @@ describe('Signer', () => {
 
         dynamicData = {
             types: {
-                Bar: [
-                    { name: 'dynamicBytes', type: 'bytes' },
-                    { name: 'dynamicString', type: 'string' },
-                ],
+                Bar: [{ name: 'dynamicBytes', type: 'bytes' }, { name: 'dynamicString', type: 'string' }],
             },
             primaryType: 'Bar',
             message: {
                 dynamicBytes: randomHex(20),
                 dynamicString: 'testing',
             },
-        }
+        };
 
         simple = {
             types: {
@@ -99,9 +93,7 @@ describe('Signer', () => {
                 third: '0x1234567890abcdef10121234567890abcdef1012',
             },
         };
-
     });
-
 
     it('should encode a basic struct', () => {
         /* eslint-disable max-len */
@@ -135,13 +127,13 @@ describe('Signer', () => {
         const encoded = signer.encodeMessageData(arrayData.types, arrayData.primaryType, arrayData.message);
         const metaMaskEncoded = TypedDataUtils.encodeData(arrayData.primaryType, arrayData.message, arrayData.types);
         expect(encoded).to.equal(metaMaskEncoded.toString('hex'));
-    })
+    });
 
     it('should match MetaMask encoding of a struct containing bool arrays', () => {
         const encoded = signer.encodeMessageData(arrayData.types, arrayData.primaryType, arrayData.message);
         const metaMaskEncoded = TypedDataUtils.encodeData(arrayData.primaryType, arrayData.message, arrayData.types);
         expect(encoded).to.equal(metaMaskEncoded.toString('hex'));
-    })
+    });
 
     it('should encode a struct', () => {
         const encoded = signer.encodeStruct(simple.primaryType, simple.types);
@@ -155,7 +147,7 @@ describe('Signer', () => {
 
     it('should match MetaMask encoding of dynamic data', () => {
         const encoded = signer.encodeMessageData(dynamicData.types, dynamicData.primaryType, dynamicData.message);
-        const metaMaskEncoded = TypedDataUtils.encodeData(dynamicData.primaryType, dynamicData.message, dynamicData.types)
+        const metaMaskEncoded = TypedDataUtils.encodeData(dynamicData.primaryType, dynamicData.message, dynamicData.types);
         expect(encoded).to.equal(metaMaskEncoded.toString('hex'));
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6252,6 +6252,18 @@ eth-sig-util@^2.5.0:
     tweetnacl "^1.0.0"
     tweetnacl-util "^0.15.0"
 
+eth-sig-util@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-2.5.2.tgz#f30b94509786fa4fbf71adb3164b1701e15724a8"
+  integrity sha512-xvDojS/4reXsw8Pz/+p/qcM5rVB61FOdPbEtMZ8FQ0YHnPEzPy5F8zAAaZ+zj5ud0SwRLWPfor2Cacjm7EzMIw==
+  dependencies:
+    buffer "^5.2.1"
+    elliptic "^6.4.0"
+    ethereumjs-abi "0.6.5"
+    ethereumjs-util "^5.1.1"
+    tweetnacl "^1.0.0"
+    tweetnacl-util "^0.15.0"
+
 eth-tx-summary@^3.1.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/eth-tx-summary/-/eth-tx-summary-3.2.4.tgz#e10eb95eb57cdfe549bf29f97f1e4f1db679035c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6240,7 +6240,7 @@ eth-sig-util@^1.4.2:
     ethereumjs-abi "git+https://github.com/ethereumjs/ethereumjs-abi.git"
     ethereumjs-util "^5.1.1"
 
-eth-sig-util@^2.3.0:
+eth-sig-util@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-2.5.0.tgz#1018cf8bef2fe275ecbd526cf3248757b0880053"
   integrity sha512-ahApxr+e1cls/GwcFSGsgRLrMqG6D6cBnK9CRHhx97O/s9ow+URIxbPvov8jfE70ZnNBdHMircoSCpi1b4QHjA==
@@ -16610,7 +16610,6 @@ websocket@1.0.29, websocket@^1.0.28:
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
-    gulp "^4.0.2"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"


### PR DESCRIPTION
## Summary
This PR makes the AZTEC implementation of signing over arrays consistent with the approach currently used by MetaMask in the `signTypedData_v4()` function of the `eth-sig-util` module. 

It is necessary in order for an EIP712 signature produced by MetaMask for use in `ZkAsset.batchConfidentialApprove()`, to be successfully validated by a `ZkAsset`.
<!--- Summarise your changes -->

## Description
`batchConfidentialApprove()` is a `ZkAsset` method used to grant control over multiple notes to a third party in one method call.  

In order to do this, an EIP712 signature has to be produced over arrays of data - specifically the `noteHashes` of the notes involved and the `spenderApprovals`, booleans as to whether permission is being granted or removed. These two variables are represented by data types `bytes32[]` and `bool[]` respectively. 

Our previous implementation, which used the `web3-eth-abi` encoder to encode arrays, resulted in a different encoding to the one generated in `signTypedData_v4()`. To ensure compatibility, this  PR adjusts our encoding and introduces an additional function to the AZTEC `typed-data` package: `encodeArray()`. This function encodes arrays of data according to the technique employed by MetaMask. 

The signature validation code, specifically the calculation of `_hashStruct` in the `batchConfidentialApprove()` method on the `ZkAsset`, has been appropriatley updated to validate these signatures. 
 
## Testing instructions
Tests have been added to both `aztec.js` and `typed-data` to ensure that 
