### PR TITLE
Only call `getFirstAddress()` when needed

### DIFF
--- a/packages/protocol/truffle-config.js
+++ b/packages/protocol/truffle-config.js
@@ -52,8 +52,13 @@ const coverageSubproviderConfig = {
     ignoreFilesGlobs: ['**/Migrations.sol', '**/node_modules/**', '**/interfaces/**', '**/test/**'],
 };
 const artifactAdapter = new TruffleArtifactAdapter(projectRoot, compilerConfig.solcVersion);
-const defaultFromAddress = getFirstAddress();
 const engine = new ProviderEngine();
+
+let defaultFromAddress;
+const testModes = ['profile', 'coverage', 'trace'];
+if (testModes.includes(process.env.MODE)) {
+    defaultFromAddress = getFirstAddress();
+}
 
 switch (process.env.MODE) {
     case 'profile':


### PR DESCRIPTION
## Summary
This PR refactors the `truffle-config.js` in the `protocol` package so that the `getFirstAddress()` function is only called when needed. This prevents unintended JSON-RPC errors.

## Description
`getFirstAddress()` pings a local node to get an Ethereum address, which is necessary for the local subproviders that enable error stack tracing, gas profiling and coverage. 

However at the moment, the `getFirstAddress()` is called regardless of the environment in which the `truffle-config` is used. This has been resulting in unexpected `JSON-RPC` errors (due to ganache not being running) when you try to call `truffle compile` for example.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
