### PR TITLE
Add missing package watch commands

### DIFF
--- a/packages/contract-addresses/package.json
+++ b/packages/contract-addresses/package.json
@@ -48,6 +48,7 @@
     "build": "./build.sh",
     "build:prod": "yarn build",
     "clean": "shx rm -rf ./lib",
-    "lint": "eslint --ignore-path ../../.eslintignore ."
+    "lint": "eslint --ignore-path ../../.eslintignore .",
+    "watch": "yarn build:dev --watch"
   }
 }

--- a/packages/contract-artifacts/package.json
+++ b/packages/contract-artifacts/package.json
@@ -46,6 +46,7 @@
     "build": "./build.sh",
     "build:prod": "yarn build",
     "clean": "shx rm -rf ./lib",
-    "lint": "eslint --ignore-path ../../.eslintignore ."
+    "lint": "eslint --ignore-path ../../.eslintignore .",
+    "watch": "yarn build:dev --watch"
   }
 }


### PR DESCRIPTION
## Summary
This PR adds a `watch` command in the `package.json` files of the `contract-artifacts` and `contract-addresses` packages. 

This is necessary to have the packages automatically build when `yarn watch` is run from the root during development periods. 
