### PR TITLE
Fix metadata format in note-access

### DIFF
--- a/packages/note-access/src/utils/decodeMetaDataToObject.js
+++ b/packages/note-access/src/utils/decodeMetaDataToObject.js
@@ -23,7 +23,7 @@ export default function decodeMetaDataToObject(metaDataStr, config, startOffset 
     });
 
     const metaDataObj = {};
-    config.forEach(({ name, length }, i) => {
+    config.forEach(({ name, length, _toString }, i) => {
         const data = [];
         const startOfDynamicData = offsetOfDynamicDataMapping[i];
         const endOfDynamicData =
@@ -40,7 +40,10 @@ export default function decodeMetaDataToObject(metaDataStr, config, startOffset 
 
         for (let j = 0; j < numberOfDynamicData; j += 1) {
             const dynamicData = dataStr.substr(lengthOfDynamicData * j + MIN_BYTES_VAR_LENGTH, lengthOfDynamicData);
-            const formattedData = length !== undefined ? dynamicData.slice(-length) : stripPrependedZeroes(dynamicData);
+            let formattedData = length !== undefined ? dynamicData.slice(-length) : stripPrependedZeroes(dynamicData);
+            if (_toString) {
+                formattedData = _toString(formattedData).replace(/^0x/, '');
+            }
             data.push(`0x${formattedData}`);
         }
         const isArrayData = length !== undefined;

--- a/packages/note-access/test/decodeMetaDataToObject.spec.js
+++ b/packages/note-access/test/decodeMetaDataToObject.spec.js
@@ -98,4 +98,41 @@ describe('decodeMetaDataToObject', () => {
             forest: '0xewjklewjlewjkjfoerejeoree',
         });
     });
+
+    it('use custom _toString function in config to format data', () => {
+        const configWithToString = [
+            {
+                name: 'food',
+                length: 10,
+                _toString: (str) => str.toUpperCase(),
+            },
+            {
+                name: 'fruit',
+                length: 6,
+            },
+            {
+                name: 'forest',
+            },
+        ];
+
+        const inputStr = [
+            '0x',
+            ensureMinVarSize(to32ByteOffset(3 * MIN_BYTES_VAR_LENGTH)),
+            ensureMinVarSize(to32ByteOffset(5 * MIN_BYTES_VAR_LENGTH)),
+            ensureMinVarSize(to32ByteOffset(8 * MIN_BYTES_VAR_LENGTH)),
+            ensureMinVarSize(1),
+            ensureMinVarSize('hamburgers'),
+            ensureMinVarSize(2),
+            ensureMinVarSize('apples'),
+            ensureMinVarSize('banana'),
+            ensureMinVarSize(1),
+            ensureMinVarSize('deerrabbitbirdsnakebear'),
+        ].join('');
+
+        expect(decodeMetaDataToObject(inputStr, configWithToString)).toEqual({
+            food: ['0xHAMBURGERS'],
+            fruit: ['0xapples', '0xbanana'],
+            forest: '0xdeerrabbitbirdsnakebear',
+        });
+    });
 });

--- a/packages/note-access/test/metadata.spec.js
+++ b/packages/note-access/test/metadata.spec.js
@@ -124,6 +124,14 @@ describe('metadata constructor', () => {
         });
     });
 
+    it('convert lowercase address to checksum address', () => {
+        expect(metadata(metadataStr.toLowerCase())).toMatchObject({
+            addresses: addressBytes.map(toChecksumAddress),
+            viewingKeys: viewingKeyBytes,
+            appData: appDataByte,
+        });
+    });
+
     it('allow zero length info', () => {
         const objWithNoAccess = {
             appData,


### PR DESCRIPTION
## Summary

When converting metadata string to object, apply `_toString` to values if it is defined in config.

## Testing instructions

New test cases are in `decodeMetaDataToObject.spec.js` and `metadata.spec.js`

## Types of changes

* Bug fix (non-breaking change which fixes an issue)
