### PR TITLE
Add delay to deploy scripts to fix migrations

### DIFF
--- a/packages/protocol/migrations/10_deploy_adjustableFactory.js
+++ b/packages/protocol/migrations/10_deploy_adjustableFactory.js
@@ -20,5 +20,12 @@ module.exports = (deployer) => {
 
             await ace.setFactory(1 * 256 ** 2 + 1 * 256 ** 1 + 2 * 256 ** 0, address);
         });
-    });
+    }).then(
+        (contract) =>
+            new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(contract);
+                }, 2000),
+            ),
+    );;
 };

--- a/packages/protocol/migrations/11_deploy_mixedFactory.js
+++ b/packages/protocol/migrations/11_deploy_mixedFactory.js
@@ -20,5 +20,12 @@ module.exports = (deployer) => {
 
             await ace.setFactory(1 * 256 ** 2 + 1 * 256 ** 1 + 3 * 256 ** 0, address);
         });
-    });
+    }).then(
+        (contract) =>
+            new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(contract);
+                }, 2000),
+            ),
+    );;
 };

--- a/packages/protocol/migrations/12_deploy_zk_asset.js
+++ b/packages/protocol/migrations/12_deploy_zk_asset.js
@@ -23,5 +23,12 @@ module.exports = (deployer, network) => {
             const aceAddress = ACE.address;
             return deployer.deploy(ZkAsset, aceAddress, erc20Address, ERC20_SCALING_FACTOR);
         });
-    });
+    }).then(
+        (contract) =>
+            new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(contract);
+                }, 2000),
+            ),
+    );;
 };

--- a/packages/protocol/migrations/13_deploy_zk_asset_adjustable.js
+++ b/packages/protocol/migrations/13_deploy_zk_asset_adjustable.js
@@ -20,5 +20,12 @@ module.exports = (deployer) => {
             const aceAddress = ACE.address;
             return deployer.deploy(ZkAssetAdjustable, aceAddress, erc20Address, ERC20_SCALING_FACTOR, 0, []);
         });
-    });
+    }).then(
+        (contract) =>
+            new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(contract);
+                }, 2000),
+            ),
+    );;
 };

--- a/packages/protocol/migrations/1_initial_migration.js
+++ b/packages/protocol/migrations/1_initial_migration.js
@@ -2,5 +2,12 @@
 const Migrations = artifacts.require('./Migrations.sol');
 
 module.exports = (deployer) => {
-    deployer.deploy(Migrations);
+    deployer.deploy(Migrations).then(
+        (contract) =>
+            new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(contract);
+                }, 2000),
+            ),
+    );
 };

--- a/packages/protocol/migrations/2_deploy_ace.js
+++ b/packages/protocol/migrations/2_deploy_ace.js
@@ -6,5 +6,12 @@ const ACE = artifacts.require('./ACE.sol');
 module.exports = (deployer) => {
     return deployer.deploy(ACE).then(async (ace) => {
         await ace.setCommonReferenceString(bn128.CRS);
-    });
+    }).then(
+        (contract) =>
+            new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(contract);
+                }, 2000),
+            ),
+    );;
 };

--- a/packages/protocol/migrations/3_deploy_join_split.js
+++ b/packages/protocol/migrations/3_deploy_join_split.js
@@ -11,5 +11,12 @@ module.exports = (deployer) => {
     return deployer.deploy(JoinSplit).then(async ({ address: joinSplitAddress }) => {
         const ace = await ACE.at(ACE.address);
         await ace.setProof(proofs.JOIN_SPLIT_PROOF, joinSplitAddress);
-    });
+    }).then(
+        (contract) =>
+            new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(contract);
+                }, 2000),
+            ),
+    );;
 };

--- a/packages/protocol/migrations/4_deploy_join_split_fluid.js
+++ b/packages/protocol/migrations/4_deploy_join_split_fluid.js
@@ -12,5 +12,12 @@ module.exports = (deployer) => {
         const ace = await ACE.at(ACE.address);
         await ace.setProof(proofs.MINT_PROOF, joinSplitFluidAddress);
         await ace.setProof(proofs.BURN_PROOF, joinSplitFluidAddress);
-    });
+    }).then(
+        (contract) =>
+            new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(contract);
+                }, 2000),
+            ),
+    );;
 };

--- a/packages/protocol/migrations/5_deploy_swap.js
+++ b/packages/protocol/migrations/5_deploy_swap.js
@@ -11,5 +11,12 @@ module.exports = (deployer) => {
     return deployer.deploy(Swap).then(async ({ address: swapAddress }) => {
         const ace = await ACE.at(ACE.address);
         await ace.setProof(proofs.SWAP_PROOF, swapAddress);
-    });
+    }).then(
+        (contract) =>
+            new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(contract);
+                }, 2000),
+            ),
+    );;
 };

--- a/packages/protocol/migrations/6_deploy_dividend.js
+++ b/packages/protocol/migrations/6_deploy_dividend.js
@@ -11,5 +11,12 @@ module.exports = (deployer) => {
     return deployer.deploy(Dividend).then(async ({ address: dividendAddress }) => {
         const ace = await ACE.at(ACE.address);
         await ace.setProof(proofs.DIVIDEND_PROOF, dividendAddress);
-    });
+    }).then(
+        (contract) =>
+            new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(contract);
+                }, 2000),
+            ),
+    );;
 };

--- a/packages/protocol/migrations/7_deploy_private_range.js
+++ b/packages/protocol/migrations/7_deploy_private_range.js
@@ -11,5 +11,12 @@ module.exports = (deployer) => {
     return deployer.deploy(PrivateRange).then(async ({ address: privateRangeAddress }) => {
         const ace = await ACE.at(ACE.address);
         await ace.setProof(proofs.PRIVATE_RANGE_PROOF, privateRangeAddress);
-    });
+    }).then(
+        (contract) =>
+            new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(contract);
+                }, 2000),
+            ),
+    );;
 };

--- a/packages/protocol/migrations/8_deploy_public_range.js
+++ b/packages/protocol/migrations/8_deploy_public_range.js
@@ -11,5 +11,12 @@ module.exports = (deployer) => {
     return deployer.deploy(PublicRange).then(async ({ address: PublicRangeAddress }) => {
         const ace = await ACE.at(ACE.address);
         await ace.setProof(proofs.PUBLIC_RANGE_PROOF, PublicRangeAddress);
-    });
+    }).then(
+        (contract) =>
+            new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(contract);
+                }, 2000),
+            ),
+    );;
 };

--- a/packages/protocol/migrations/9_deploy_baseFactory.js
+++ b/packages/protocol/migrations/9_deploy_baseFactory.js
@@ -20,5 +20,12 @@ module.exports = (deployer) => {
 
             await ace.setFactory(1 * 256 ** 2 + 1 * 256 ** 1 + 1 * 256 ** 0, address);
         });
-    });
+    }).then(
+        (contract) =>
+            new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(contract);
+                }, 2000),
+            ),
+    );;
 };


### PR DESCRIPTION
## Summary
Building the `artifacts` on `circleci` does not currently work - errors around `nonce too low` and deploy scripts hanging indefinitely occur. 

This may be due to multiple deploy transactions being handled by different nodes simultaneously - meaning that once tx A is processed, the yet to be processed but processing tx B will have an incorrect nonce. As a result when tx B is procssed, a `nonce too low` error will occur. 

This PR adds a delay into each deployment script, to attempt to prevent this from happening. On local deploys it appears to fix the problem.