### PR TITLE
Update Dividend validator + za, zb tests

### DIFF
--- a/packages/aztec.js/src/proof/proofs/UTILITY/epoch0/dividend/index.js
+++ b/packages/aztec.js/src/proof/proofs/UTILITY/epoch0/dividend/index.js
@@ -26,7 +26,7 @@ class DividendProof66561 extends Proof {
     constructor(notionalNote, residualNote, targetNote, sender, za, zb) {
         const publicValue = constants.ZERO_BN;
         const publicOwner = constants.addresses.ZERO_ADDRESS;
-        super(ProofType.DIVIDEND.name, [notionalNote], [residualNote, targetNote], sender, publicValue, publicOwner);
+        super(ProofType.DIVIDEND.name, [notionalNote], [targetNote, residualNote], sender, publicValue, publicOwner);
 
         this.za = new BN(za);
         this.zb = new BN(zb);

--- a/packages/aztec.js/test/proof/dividend/verifier.js
+++ b/packages/aztec.js/test/proof/dividend/verifier.js
@@ -14,10 +14,10 @@ describe('Dividend Proof Verifier', () => {
     const notionalNoteValue = 90;
     const { publicKey } = secp256k1.generateAccount();
     let residualNote = {};
-    const residualNoteValue = 4;
+    const residualNoteValue = 50;
     const sender = randomHex(20);
     let targetNote = {};
-    const targetNoteValue = 50;
+    const targetNoteValue = 4;
 
     before(async () => {
         notionalNote = await note.create(publicKey, notionalNoteValue);

--- a/packages/dev-utils/src/constants.js
+++ b/packages/dev-utils/src/constants.js
@@ -16,7 +16,7 @@ const constants = {
      *  @type {string}
      *  @default 10e6
      */
-    K_MAX: 10e6,
+    K_MAX: 10000000,
     /** Maximum value that can be held in an AZTEC note during tests
      *  @constant K_MAX_TEST
      *  @type {string}

--- a/packages/dev-utils/src/constants.js
+++ b/packages/dev-utils/src/constants.js
@@ -14,7 +14,7 @@ const constants = {
     /** Maximum value that can be held in an AZTEC Note
      *  @constant K_MAX
      *  @type {string}
-     *  @default 10e9
+     *  @default 10e6
      */
     K_MAX: 10e6,
     /** Maximum value that can be held in an AZTEC note during tests

--- a/packages/dev-utils/src/constants.js
+++ b/packages/dev-utils/src/constants.js
@@ -14,15 +14,15 @@ const constants = {
     /** Maximum value that can be held in an AZTEC Note
      *  @constant K_MAX
      *  @type {string}
-     *  @default 1048576
+     *  @default 10e9
      */
-    K_MAX: 1048576,
+    K_MAX: 10e6,
     /** Maximum value that can be held in an AZTEC note during tests
      *  @constant K_MAX_TEST
      *  @type {string}
      *  @default 0
      */
-    K_MAX_TEST: 14336,
+    K_MAX_TEST: 16000,
     /** Minimum value that can be held in an AZTEC note
      *  @constant K_MIN
      *  @type { string }

--- a/packages/integration-test/test/integration.js
+++ b/packages/integration-test/test/integration.js
@@ -111,8 +111,8 @@ contract('Integration', (accounts) => {
             const za = 100;
             const zb = 5;
             const notionalNote = await note.create(aztecAccount.publicKey, 90);
-            const residualNote = await note.create(aztecAccount.publicKey, 4);
-            const targetNote = await note.create(aztecAccount.publicKey, 50);
+            const targetNote = await note.create(aztecAccount.publicKey, 4);
+            const residualNote = await note.create(aztecAccount.publicKey, 50);
 
             const proof = new DividendProof(notionalNote, residualNote, targetNote, sender, za, zb);
             const data = proof.encodeABI();

--- a/packages/protocol/contracts/ACE/validators/dividend/Dividend.sol
+++ b/packages/protocol/contracts/ACE/validators/dividend/Dividend.sol
@@ -73,13 +73,13 @@ contract Dividend {
                 let zb := mod(calldataload(0x164), gen_order)
 
 
-                // Check that za < kMax
+                // Check that za <= kMax
                 if gt(za, 10000000) {
                     mstore(0x00, 400)
                     revert(0x00, 0x20)
                 }
 
-                // Check that zb < kMax
+                // Check that zb <= kMax
                 if gt(zb, 10000000) {
                     mstore(0x00, 400)
                     revert(0x00, 0x20)

--- a/packages/protocol/contracts/ACE/validators/dividend/Dividend.sol
+++ b/packages/protocol/contracts/ACE/validators/dividend/Dividend.sol
@@ -74,13 +74,13 @@ contract Dividend {
 
 
                 // Check that za < kMax
-                if gt(za, 1048576) {
+                if gt(za, 10000000) {
                     mstore(0x00, 400)
                     revert(0x00, 0x20)
                 }
 
                 // Check that zb < kMax
-                if gt(zb, 1048576) {
+                if gt(zb, 10000000) {
                     mstore(0x00, 400)
                     revert(0x00, 0x20)
                 }

--- a/packages/protocol/test/ACE/validators/dividend/abiEncoder.js
+++ b/packages/protocol/test/ACE/validators/dividend/abiEncoder.js
@@ -18,8 +18,8 @@ const getNotes = async (notionalNoteValue, residualNoteValue, targetNoteValue) =
 
 const getDefaultNotes = async () => {
     const notionalNoteValue = 90;
-    const targetNoteValue = 50;
-    const residualNoteValue = 4;
+    const targetNoteValue = 4;
+    const residualNoteValue = 50;
     const { notionalNote, residualNote, targetNote } = await getNotes(notionalNoteValue, residualNoteValue, targetNoteValue);
     const za = 100;
     const zb = 5;
@@ -47,15 +47,15 @@ contract('Dividend ABI Encoder', (accounts) => {
         expect(decoded[0].inputNotes[0].noteHash).to.equal(notionalNote.noteHash);
         expect(decoded[0].inputNotes[0].owner).to.equal(notionalNote.owner.toLowerCase());
 
-        expect(decoded[0].outputNotes[0].gamma.eq(residualNote.gamma)).to.equal(true);
-        expect(decoded[0].outputNotes[0].sigma.eq(residualNote.sigma)).to.equal(true);
-        expect(decoded[0].outputNotes[0].noteHash).to.equal(residualNote.noteHash);
-        expect(decoded[0].outputNotes[0].owner).to.equal(residualNote.owner.toLowerCase());
+        expect(decoded[0].outputNotes[0].gamma.eq(targetNote.gamma)).to.equal(true);
+        expect(decoded[0].outputNotes[0].sigma.eq(targetNote.sigma)).to.equal(true);
+        expect(decoded[0].outputNotes[0].noteHash).to.equal(targetNote.noteHash);
+        expect(decoded[0].outputNotes[0].owner).to.equal(targetNote.owner.toLowerCase());
 
-        expect(decoded[0].outputNotes[1].gamma.eq(targetNote.gamma)).to.equal(true);
-        expect(decoded[0].outputNotes[1].sigma.eq(targetNote.sigma)).to.equal(true);
-        expect(decoded[0].outputNotes[1].noteHash).to.equal(targetNote.noteHash);
-        expect(decoded[0].outputNotes[1].owner).to.equal(targetNote.owner.toLowerCase());
+        expect(decoded[0].outputNotes[1].gamma.eq(residualNote.gamma)).to.equal(true);
+        expect(decoded[0].outputNotes[1].sigma.eq(residualNote.sigma)).to.equal(true);
+        expect(decoded[0].outputNotes[1].noteHash).to.equal(residualNote.noteHash);
+        expect(decoded[0].outputNotes[1].owner).to.equal(residualNote.owner.toLowerCase());
 
         expect(decoded[0].publicOwner).to.equal(proof.publicOwner.toLowerCase());
         expect(decoded[0].publicValue).to.equal(proof.publicValue.toNumber());

--- a/packages/protocol/test/ACE/validators/dividend/index.js
+++ b/packages/protocol/test/ACE/validators/dividend/index.js
@@ -4,7 +4,6 @@ const bn128 = require('@aztec/bn128');
 const { constants } = require('@aztec/dev-utils');
 const secp256k1 = require('@aztec/secp256k1');
 const BN = require('bn.js');
-const sinon = require('sinon');
 const truffleAssert = require('truffle-assertions');
 const { padLeft, randomHex } = require('web3-utils');
 

--- a/packages/protocol/test/ACE/validators/dividend/index.js
+++ b/packages/protocol/test/ACE/validators/dividend/index.js
@@ -80,7 +80,7 @@ contract('Dividend Validator', (accounts) => {
             const data = proof.encodeABI();
             const result = await dividendValidator.validateDividend(data, sender, bn128.CRS, { from: sender });
             expect(result).to.equal(proof.eth.outputs);
-        })
+        });
 
         it('should validate proof when za = K_MAX', async () => {
             // (k1 * zb) = (k2 * za) + k3
@@ -238,7 +238,7 @@ contract('Dividend Validator', (accounts) => {
         it('should fail to validate proof when zb = 0', async () => {
             // (k1 * zb) = (k2 * za) + k3
             // (10 * 0) = (3 * 0) + 0
-            // results in \bar{k3} = 0, which upon exponentiating will produce a 
+            // results in \bar{k3} = 0, which upon exponentiating will produce a
             // point at infinity. This should revert
             const za = 0;
             const zb = 0;
@@ -263,7 +263,7 @@ contract('Dividend Validator', (accounts) => {
         it('should fail for za > K_MAX', async () => {
             // (k1 * zb) = (k2 * za) + k3
             // (1 * 1) = (0 * K_MAX + 1) + 1
-            //  => K_MAX - 1 = 1 
+            //  => K_MAX - 1 = 1
 
             const za = K_MAX + 1;
             const zb = 1;
@@ -286,7 +286,7 @@ contract('Dividend Validator', (accounts) => {
         it('should fail for for zb > K_MAX', async () => {
             // (k1 * zb) = (k2 * za) + k3
             // (1 * K_MAX + 100) = (1 * K_MAX - 1) + 101
-            //  => K_MAX - 1 = 1 
+            //  => K_MAX - 1 = 1
             const za = K_MAX - 1;
             const zb = K_MAX + 100;
 
@@ -310,8 +310,8 @@ contract('Dividend Validator', (accounts) => {
             // (1 * 4294967293) = (1 * 4294967295) + 0
             //  => 4294967295 = 4294967295
 
-            const za = 2**32 - 1; // 4294967295
-            const zb = 2**32 - 1; // 4294967295
+            const za = 2 ** 32 - 1; // 4294967295
+            const zb = 2 ** 32 - 1; // 4294967295
 
             const k1 = 1;
             const k2 = 1;

--- a/packages/protocol/test/ACE/validators/dividend/index.js
+++ b/packages/protocol/test/ACE/validators/dividend/index.js
@@ -4,6 +4,7 @@ const bn128 = require('@aztec/bn128');
 const { constants } = require('@aztec/dev-utils');
 const secp256k1 = require('@aztec/secp256k1');
 const BN = require('bn.js');
+const sinon = require('sinon');
 const truffleAssert = require('truffle-assertions');
 const { padLeft, randomHex } = require('web3-utils');
 
@@ -16,6 +17,7 @@ Dividend.abi = DividendInterface.abi;
 let dividendValidator;
 const Keccak = keccak;
 const { publicKey } = secp256k1.generateAccount();
+const { K_MAX } = constants;
 
 const getNotes = async (notionalNoteValue, residualNoteValue, targetNoteValue) => {
     const notionalNote = await note.create(publicKey, notionalNoteValue);
@@ -26,15 +28,15 @@ const getNotes = async (notionalNoteValue, residualNoteValue, targetNoteValue) =
 
 const getDefaultNotes = async () => {
     const notionalNoteValue = 90;
-    const residualNoteValue = 4;
-    const targetNoteValue = 50;
+    const residualNoteValue = 50;
+    const targetNoteValue = 4;
     const { notionalNote, residualNote, targetNote } = await getNotes(notionalNoteValue, residualNoteValue, targetNoteValue);
     const za = 100;
     const zb = 5;
     return { notionalNote, residualNote, targetNote, za, zb };
 };
 
-contract.only('Dividend Validator', (accounts) => {
+contract('Dividend Validator', (accounts) => {
     const sender = accounts[0];
 
     before(async () => {
@@ -61,19 +63,66 @@ contract.only('Dividend Validator', (accounts) => {
         });
 
         it('should validate proof when za = 0', async () => {
+            // (k1 * zb) = (k2 * za) + k3
+            // (10 * 2) = (3 * 0) + 20
+            const za = 0;
+            const zb = 2;
 
+            const k1 = 10;
+            const k2 = 3;
+            const k3 = 20;
+            const notionalNote = await note.create(publicKey, k1);
+            const targetNote = await note.create(publicKey, k2);
+            const residualNote = await note.create(publicKey, k3);
+
+            const proof = new DividendProof(notionalNote, residualNote, targetNote, sender, za, zb);
+            proof.challenge = proof.challenge.add(bn128.groupModulus);
+            proof.constructOutputs();
+            const data = proof.encodeABI();
+            const result = await dividendValidator.validateDividend(data, sender, bn128.CRS, { from: sender });
+            expect(result).to.equal(proof.eth.outputs);
         })
 
         it('should validate proof when za = K_MAX', async () => {
+            // (k1 * zb) = (k2 * za) + k3
+            // (4 * K_MAX/2) = (2 * K_MAX) + 0
+            const za = K_MAX;
+            const zb = K_MAX / 2;
 
-        });
+            const k1 = 4;
+            const k2 = 2;
+            const k3 = 0;
+            const notionalNote = await note.create(publicKey, k1);
+            const targetNote = await note.create(publicKey, k2);
+            const residualNote = await note.create(publicKey, k3);
 
-        it('should validate proof when zb = 0', async () => {
-
+            const proof = new DividendProof(notionalNote, residualNote, targetNote, sender, za, zb);
+            proof.challenge = proof.challenge.add(bn128.groupModulus);
+            proof.constructOutputs();
+            const data = proof.encodeABI();
+            const result = await dividendValidator.validateDividend(data, sender, bn128.CRS, { from: sender });
+            expect(result).to.equal(proof.eth.outputs);
         });
 
         it('should validate proof when zb = K_MAX', async () => {
+            // (k1 * zb) = (k2 * za) + k3
+            // (1 * KMAX) = (3 * 3333333) + 0
+            const za = K_MAX / 2; // K_MAX / 3
+            const zb = K_MAX;
 
+            const k1 = 1;
+            const k2 = 2;
+            const k3 = 0;
+            const notionalNote = await note.create(publicKey, k1);
+            const targetNote = await note.create(publicKey, k2);
+            const residualNote = await note.create(publicKey, k3);
+
+            const proof = new DividendProof(notionalNote, residualNote, targetNote, sender, za, zb);
+            proof.challenge = proof.challenge.add(bn128.groupModulus);
+            proof.constructOutputs();
+            const data = proof.encodeABI();
+            const result = await dividendValidator.validateDividend(data, sender, bn128.CRS, { from: sender });
+            expect(result).to.equal(proof.eth.outputs);
         });
     });
 
@@ -187,25 +236,46 @@ contract.only('Dividend Validator', (accounts) => {
             );
         });
 
-        it('should fail for for za > K_MAX', async () => {
-            const { notionalNote, residualNote, targetNote } = await getDefaultNotes();
-            const za = constants.K_MAX + 100;
-            const zb = 5;
+        it('should fail to validate proof when zb = 0', async () => {
+            // (k1 * zb) = (k2 * za) + k3
+            // (10 * 0) = (3 * 0) + 0
+            // results in \bar{k3} = 0, which upon exponentiating will produce a 
+            // point at infinity. This should revert
+            const za = 0;
+            const zb = 0;
+
+            const k1 = 10;
+            const k2 = 3;
+            const k3 = 0;
+            const notionalNote = await note.create(publicKey, k1);
+            const targetNote = await note.create(publicKey, k2);
+            const residualNote = await note.create(publicKey, k3);
+
             const proof = new DividendProof(notionalNote, residualNote, targetNote, sender, za, zb);
+            proof.challenge = proof.challenge.add(bn128.groupModulus);
+            proof.constructOutputs();
             const data = proof.encodeABI();
             await truffleAssert.reverts(
-                dividendValidator.validateDividend(data, sender, bn128.CRS),
+                dividendValidator.validateDividend(data, sender, bn128.CRS, { from: sender }),
                 truffleAssert.ErrorType.REVERT,
             );
         });
 
-        it('should fail for za < 0', async () => {
-            // 0 is the lower bound for za
-            const { notionalNote, residualNote, targetNote } = await getDefaultNotes();
-            const za = -5
-            const zb = 100;
+        it('should fail for za > K_MAX', async () => {
+            // (k1 * zb) = (k2 * za) + k3
+            // (1 * 1) = (0 * K_MAX + 1) + 1
+            //  => K_MAX - 1 = 1 
 
-            // note that the check for 0 < za < K_MAX occcurs at the start of the validator
+            const za = K_MAX + 1;
+            const zb = 1;
+
+            const k1 = 1;
+            const k2 = 0;
+            const k3 = 1;
+            const notionalNote = await note.create(publicKey, k1);
+            const targetNote = await note.create(publicKey, k2);
+            const residualNote = await note.create(publicKey, k3);
+
             const proof = new DividendProof(notionalNote, residualNote, targetNote, sender, za, zb);
             const data = proof.encodeABI();
             await truffleAssert.reverts(
@@ -215,9 +285,19 @@ contract.only('Dividend Validator', (accounts) => {
         });
 
         it('should fail for for zb > K_MAX', async () => {
-            const { notionalNote, residualNote, targetNote } = await getDefaultNotes();
-            const za = 100;
-            const zb = constants.K_MAX + 100;
+            // (k1 * zb) = (k2 * za) + k3
+            // (1 * K_MAX + 100) = (1 * K_MAX - 1) + 101
+            //  => K_MAX - 1 = 1 
+            const za = K_MAX - 1;
+            const zb = K_MAX + 100;
+
+            const k1 = 1;
+            const k2 = 1;
+            const k3 = 101;
+            const notionalNote = await note.create(publicKey, k1);
+            const targetNote = await note.create(publicKey, k2);
+            const residualNote = await note.create(publicKey, k3);
+
             const proof = new DividendProof(notionalNote, residualNote, targetNote, sender, za, zb);
             const data = proof.encodeABI();
             await truffleAssert.reverts(
@@ -226,9 +306,27 @@ contract.only('Dividend Validator', (accounts) => {
             );
         });
 
-        it('should fail for zb < 0', async () => {
-            // 0 is the lower bound for zb
+        it('should fail for large za, zb', async () => {
+            // (k1 * zb) = (k2 * za) + k3
+            // (1 * 4294967293) = (1 * 4294967295) + 0
+            //  => 4294967295 = 4294967295
 
+            const za = 2**32 - 1; // 4294967295
+            const zb = 2**32 - 1; // 4294967295
+
+            const k1 = 1;
+            const k2 = 1;
+            const k3 = 0;
+            const notionalNote = await note.create(publicKey, k1);
+            const targetNote = await note.create(publicKey, k2);
+            const residualNote = await note.create(publicKey, k3);
+
+            const proof = new DividendProof(notionalNote, residualNote, targetNote, sender, za, zb);
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                dividendValidator.validateDividend(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
         });
 
         it('should fail if malformed proof data', async () => {

--- a/packages/protocol/test/ACE/validators/dividend/index.js
+++ b/packages/protocol/test/ACE/validators/dividend/index.js
@@ -34,7 +34,7 @@ const getDefaultNotes = async () => {
     return { notionalNote, residualNote, targetNote, za, zb };
 };
 
-contract('Dividend Validator', (accounts) => {
+contract.only('Dividend Validator', (accounts) => {
     const sender = accounts[0];
 
     before(async () => {
@@ -58,6 +58,22 @@ contract('Dividend Validator', (accounts) => {
             const data = proof.encodeABI();
             const result = await dividendValidator.validateDividend(data, sender, bn128.CRS, { from: sender });
             expect(result).to.equal(proof.eth.outputs);
+        });
+
+        it('should validate proof when za = 0', async () => {
+
+        })
+
+        it('should validate proof when za = K_MAX', async () => {
+
+        });
+
+        it('should validate proof when zb = 0', async () => {
+
+        });
+
+        it('should validate proof when zb = K_MAX', async () => {
+
         });
     });
 
@@ -183,6 +199,21 @@ contract('Dividend Validator', (accounts) => {
             );
         });
 
+        it('should fail for za < 0', async () => {
+            // 0 is the lower bound for za
+            const { notionalNote, residualNote, targetNote } = await getDefaultNotes();
+            const za = -5
+            const zb = 100;
+
+            // note that the check for 0 < za < K_MAX occcurs at the start of the validator
+            const proof = new DividendProof(notionalNote, residualNote, targetNote, sender, za, zb);
+            const data = proof.encodeABI();
+            await truffleAssert.reverts(
+                dividendValidator.validateDividend(data, sender, bn128.CRS),
+                truffleAssert.ErrorType.REVERT,
+            );
+        });
+
         it('should fail for for zb > K_MAX', async () => {
             const { notionalNote, residualNote, targetNote } = await getDefaultNotes();
             const za = 100;
@@ -193,6 +224,11 @@ contract('Dividend Validator', (accounts) => {
                 dividendValidator.validateDividend(data, sender, bn128.CRS),
                 truffleAssert.ErrorType.REVERT,
             );
+        });
+
+        it('should fail for zb < 0', async () => {
+            // 0 is the lower bound for zb
+
         });
 
         it('should fail if malformed proof data', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7591,7 +7591,7 @@ debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -9788,7 +9788,7 @@ file-loader@^4.2.0:
     loader-utils "^1.2.3"
     schema-utils "^2.5.0"
 
-"file-saver@github:eligrey/FileSaver.js#1.3.8":
+file-saver@eligrey/FileSaver.js#1.3.8:
   version "1.3.8"
   resolved "https://codeload.github.com/eligrey/FileSaver.js/tar.gz/e865e37af9f9947ddcced76b549e27dc45c1cb2e"
 
@@ -11707,7 +11707,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -14244,11 +14244,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -14257,32 +14252,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -14523,11 +14496,6 @@ lodash.random@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.random/-/lodash.random-3.2.0.tgz#96e24e763333199130d2c9e2fd57f91703cc262d"
   integrity sha1-luJOdjMzGZEw0sni/Vf5FwPMJi0=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.reverse@^4.0.1:
   version "4.0.1"
@@ -15846,22 +15814,6 @@ node-polyglot@^2.3.1:
     has "^1.0.3"
     string.prototype.trim "^1.1.2"
     warning "^4.0.3"
-
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
 
 node-pre-gyp@^0.13.0:
   version "0.13.0"
@@ -21057,7 +21009,7 @@ tar@^2.0.0:
     fstream "^1.0.12"
     inherits "2"
 
-tar@^4, tar@^4.0.2, tar@^4.4.10, tar@^4.4.12, tar@^4.4.13, tar@^4.4.2, tar@^4.4.8:
+tar@^4, tar@^4.0.2, tar@^4.4.10, tar@^4.4.12, tar@^4.4.13, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
## Summary
This PR updates the hard coded `K_MAX` value in the `Dividend` validator contract from the previous internal CRS value to the production CRS value - 10 million. 

It also adds various success and failure tests for `za`, `zb`'s relation to `K_MAX`.

Lastly, it corrects the previously incorrect labelling on which notes involved in the dividend proof are the `targetNote` and the `residualNote`. 
