### PR TITLE
Support for mainnet contract artifacts and addresses

### DIFF
--- a/packages/contract-addresses/src/index.js
+++ b/packages/contract-addresses/src/index.js
@@ -1,5 +1,6 @@
 const { isUndefined } = require('lodash');
 
+const mainnetAddresses = require('../addresses/mainnet');
 const rinkebyAddresses = require('../addresses/rinkeby');
 const ropstenAddresses = require('../addresses/ropsten');
 
@@ -11,6 +12,9 @@ const NetworkId = {
 };
 
 const networkToAddresses = {
+    '1': {
+        ...mainnetAddresses,
+    },
     '3': {
         ...ropstenAddresses,
     },

--- a/packages/contract-addresses/src/index.js
+++ b/packages/contract-addresses/src/index.js
@@ -1,6 +1,6 @@
 const { isUndefined } = require('lodash');
 
-const mainnetAddresses = require('../addresses/mainnet');
+// const mainnetAddresses = require('../addresses/mainnet');
 const rinkebyAddresses = require('../addresses/rinkeby');
 const ropstenAddresses = require('../addresses/ropsten');
 
@@ -12,9 +12,9 @@ const NetworkId = {
 };
 
 const networkToAddresses = {
-    '1': {
-        ...mainnetAddresses,
-    },
+    // '1': {
+    //     ...mainnetAddresses,
+    // },
     '3': {
         ...ropstenAddresses,
     },

--- a/packages/contract-artifacts/src/index.js
+++ b/packages/contract-artifacts/src/index.js
@@ -1,5 +1,7 @@
 /* eslint-disable */
 const ACE = require('../artifacts/ACE');
+const AccountRegistryManager = require('../artifacts/AccountRegistryManager');
+const Behaviour20200106 = requrie('../artifacts/Behaviour20200106');
 const Dividend = require('../artifacts/Dividend');
 const DividendABIEncoder = require('../artifacts/DividendABIEncoder');
 const DividendInterface = require('../artifacts/DividendInterface');
@@ -44,6 +46,8 @@ const ZkAssetOwnableBase = require('../artifacts/ZkAssetOwnableBase');
 
 module.exports = {
     ACE,
+    AccountRegistryManager,
+    Behaviour20200106,
     Dividend,
     DividendABIEncoder,
     DividendInterface,

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -95,7 +95,7 @@
         "generate:styles": "guacamole generateStyles",
         "generate:testData": "babel-node ./tests/generateTestData",
         "lint": "eslint ./ --color",
-        "test": "jest ./src",
+        "test": "jest -i ./**",
         "build:dev": "webpack --config webpack.dev.js",
         "build": "yarn build:prod",
         "build:prod": "webpack --config webpack.prod.js",

--- a/packages/monorepo-scripts/addresses/update.js
+++ b/packages/monorepo-scripts/addresses/update.js
@@ -9,6 +9,7 @@ const CONTRACT_ADDRESSES_PATH = path.join(PACKAGES_PATH, 'contract-addresses');
 const CONTRACTS_DIR = path.join(PACKAGES_PATH, 'protocol', 'build', 'contracts');
 const RINKEBY_ADDRESSES_FILE = path.join(CONTRACT_ADDRESSES_PATH, 'addresses', 'rinkeby.json');
 const ROPSTEN_ADDRESSES_FILE = path.join(CONTRACT_ADDRESSES_PATH, 'addresses', 'ropsten.json');
+const MAINNET_ADDRESSES_FILE = path.join(CONTRACT_ADDRESSES_PATH, 'addresses', 'mainnet.json');
 
 const deployedContracts = [
     'ACE',
@@ -29,6 +30,7 @@ const deployedContracts = [
 
 const rinkebyAddresses = {};
 const ropstenAddresses = {};
+const mainnetAddresses = {};
 
 const extractNetworkAddress = async (filename) => {
     const filenameWithoutExtension = filename.replace('.json', '');
@@ -49,11 +51,18 @@ const extractNetworkAddress = async (filename) => {
         throw new Error(`Ropsten address not found for ${filenameWithoutExtension}`);
     }
     ropstenAddresses[filenameWithoutExtension] = content.networks[NetworkId.Ropsten].address;
+
+    // Mainnet
+    if (!content.networks[NetworkId.Mainnet]) {
+        throw new Error(`Mainnet address not found for ${filenameWithoutExtension}`);
+    }
+    mainnetAddresses[filenameWithoutExtension] = content.networks[NetworkId.Mainnet].address;
 };
 
 const updateTestnetJsons = async () => {
     await fs.writeFile(RINKEBY_ADDRESSES_FILE, JSON.stringify(rinkebyAddresses, null, 4));
     await fs.writeFile(ROPSTEN_ADDRESSES_FILE, JSON.stringify(ropstenAddresses, null, 4));
+    await fs.writeFile(MAINNET_ADDRESSES_FILE, JSON.stringify(mainnetAddresses, null, 4));
 };
 
 const updateAddresses = async () => {

--- a/packages/monorepo-scripts/addresses/update.js
+++ b/packages/monorepo-scripts/addresses/update.js
@@ -9,7 +9,7 @@ const CONTRACT_ADDRESSES_PATH = path.join(PACKAGES_PATH, 'contract-addresses');
 const CONTRACTS_DIR = path.join(PACKAGES_PATH, 'protocol', 'build', 'contracts');
 const RINKEBY_ADDRESSES_FILE = path.join(CONTRACT_ADDRESSES_PATH, 'addresses', 'rinkeby.json');
 const ROPSTEN_ADDRESSES_FILE = path.join(CONTRACT_ADDRESSES_PATH, 'addresses', 'ropsten.json');
-const MAINNET_ADDRESSES_FILE = path.join(CONTRACT_ADDRESSES_PATH, 'addresses', 'mainnet.json');
+// const MAINNET_ADDRESSES_FILE = path.join(CONTRACT_ADDRESSES_PATH, 'addresses', 'mainnet.json');
 
 const deployedContracts = [
     'ACE',
@@ -30,7 +30,7 @@ const deployedContracts = [
 
 const rinkebyAddresses = {};
 const ropstenAddresses = {};
-const mainnetAddresses = {};
+// const mainnetAddresses = {};
 
 const extractNetworkAddress = async (filename) => {
     const filenameWithoutExtension = filename.replace('.json', '');
@@ -52,17 +52,17 @@ const extractNetworkAddress = async (filename) => {
     }
     ropstenAddresses[filenameWithoutExtension] = content.networks[NetworkId.Ropsten].address;
 
-    // Mainnet
-    if (!content.networks[NetworkId.Mainnet]) {
-        throw new Error(`Mainnet address not found for ${filenameWithoutExtension}`);
-    }
-    mainnetAddresses[filenameWithoutExtension] = content.networks[NetworkId.Mainnet].address;
+    // // Mainnet
+    // if (!content.networks[NetworkId.Mainnet]) {
+    //     throw new Error(`Mainnet address not found for ${filenameWithoutExtension}`);
+    // }
+    // mainnetAddresses[filenameWithoutExtension] = content.networks[NetworkId.Mainnet].address;
 };
 
 const updateTestnetJsons = async () => {
     await fs.writeFile(RINKEBY_ADDRESSES_FILE, JSON.stringify(rinkebyAddresses, null, 4));
     await fs.writeFile(ROPSTEN_ADDRESSES_FILE, JSON.stringify(ropstenAddresses, null, 4));
-    await fs.writeFile(MAINNET_ADDRESSES_FILE, JSON.stringify(mainnetAddresses, null, 4));
+    // await fs.writeFile(MAINNET_ADDRESSES_FILE, JSON.stringify(mainnetAddresses, null, 4));
 };
 
 const updateAddresses = async () => {

--- a/packages/monorepo-scripts/artifacts/orchestrate.sh
+++ b/packages/monorepo-scripts/artifacts/orchestrate.sh
@@ -36,7 +36,7 @@ yarn deploy:rinkeby
 yarn deploy:ropsten
 
 # Run mainnet deployment script
-yarn deploy:mainnet
+# yarn deploy:mainnet
 
 # Extract addresses from the newly generated truffle artifacts
 cd ../../

--- a/packages/monorepo-scripts/artifacts/orchestrate.sh
+++ b/packages/monorepo-scripts/artifacts/orchestrate.sh
@@ -35,6 +35,9 @@ cd packages/protocol
 yarn deploy:rinkeby
 yarn deploy:ropsten
 
+# Run mainnet deployment script
+yarn deploy:mainnet
+
 # Extract addresses from the newly generated truffle artifacts
 cd ../../
 yarn script:update:addresses

--- a/packages/protocol/migrations/15_deploy_accountRegistryManager.js
+++ b/packages/protocol/migrations/15_deploy_accountRegistryManager.js
@@ -12,20 +12,22 @@ const ACE = artifacts.require('./ACE.sol');
 module.exports = (deployer, network) => {
     if (process.env.LOCAL_TRUSTED_GSN_SIGNER_ADDRESS || process.env.TRUSTED_GSN_SIGNER_ADDRESS) {
         const useLocal = network === 'development' || network === 'test';
-        return deployer.deploy(
-            AccountRegistryManager,
-            AccountRegistryBehaviour.address,
-            ACE.address,
-            useLocal ? process.env.LOCAL_TRUSTED_GSN_SIGNER_ADDRESS : process.env.TRUSTED_GSN_SIGNER_ADDRESS,
-        ).then(async (contract) => {
-            const WEB3_PROVIDER_URL = 'http://127.0.0.1:8545';
-            const web3 = new Web3(WEB3_PROVIDER_URL);
-            const proxyAddress = await contract.proxyAddress.call();
-            await fundRecipient(web3, {
-                recipient: proxyAddress,
-                amount: toWei('1'),
+        return deployer
+            .deploy(
+                AccountRegistryManager,
+                AccountRegistryBehaviour.address,
+                ACE.address,
+                useLocal ? process.env.LOCAL_TRUSTED_GSN_SIGNER_ADDRESS : process.env.TRUSTED_GSN_SIGNER_ADDRESS,
+            )
+            .then(async (contract) => {
+                const WEB3_PROVIDER_URL = 'http://127.0.0.1:8545';
+                const web3 = new Web3(WEB3_PROVIDER_URL);
+                const proxyAddress = await contract.proxyAddress.call();
+                await fundRecipient(web3, {
+                    recipient: proxyAddress,
+                    amount: toWei('1'),
+                });
             });
-        });
     }
 
     return null;

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -73,6 +73,7 @@
     "coverage": "scripts/coverage.sh",
     "deploy:rinkeby": "truffle migrate --network rinkeby",
     "deploy:ropsten": "truffle migrate --network ropsten",
+    "deploy:mainnet": "truffle migrate --network mainnet",
     "lint": "yarn lint:js && yarn lint:sol",
     "lint:js": "eslint --ignore-path ../../.eslintignore .",
     "lint:sol": "solhint --ignore-path ../../.solhintignore \"contracts/**/*.sol\"",


### PR DESCRIPTION
**Note: If this PR is merged into `develop` it will result in an automated circleci mainnet deploy**

## Summary
This PR adds support for storing deployed `mainnet` contract artifacts and addresses. The packages should auto-update in the build pipeline with the relevant info. 

It also adds missing contract artifacts into the `contract-artifacts` package for the `AccountRegistry`