### PR TITLE
Fix sdk EventService and some minor issues

### DIFF
--- a/packages/extension/demo/1_apis-usage/create-asset.js
+++ b/packages/extension/demo/1_apis-usage/create-asset.js
@@ -47,7 +47,7 @@
     const erc20Address = deployedERC20.address;
     addAssetStatus(`✓ ERC20 deployed - ${erc20Address}`, true);
 
-    addAssetStatus('Deploying ZkAsset...');
+    addAssetStatus('Deploying zkAsset...');
     const scalingFactor = document.getElementById('new-asset-scaling-factor').value;
     const aceAddress = window.aztec.web3.getAddress('ACE');
     const ZkAsset = await fetchContract('ZkAssetOwnable');
@@ -60,7 +60,7 @@
       ],
     );
     const zkAssetAddress = deployedZkAsset.address;
-    addAssetStatus(`✓ ZkAsset deployed - ${zkAssetAddress}`, true);
+    addAssetStatus(`✓ zkAsset deployed - ${zkAssetAddress}`, true);
 
     if (value) {
       const account = window.aztec.web3.account();
@@ -76,7 +76,7 @@
       addAssetStatus(`✓ ERC20 balance = ${value}`, true);
     }
 
-    addAssetStatus(`✓ ZkAsset created with initial ERC20 balance = ${value}`, true);
+    addAssetStatus(`✓ zkAsset created with initial ERC20 balance = ${value}`, true);
 
     await sleep(500);
 

--- a/packages/extension/src/background/services/EventService/helpers/NotesWatcher/index.js
+++ b/packages/extension/src/background/services/EventService/helpers/NotesWatcher/index.js
@@ -1,5 +1,4 @@
 import async from 'async';
-import NoteService from '~/background/services/NoteService';
 import {
     subscription as NoteSubscription,
     saveNotes,
@@ -210,20 +209,7 @@ class Watcher {
             if (groupedNotes.isEmpty()) {
                 return;
             }
-            const {
-                createNotes,
-                destroyNotes,
-                updateNotes,
-            } = groupedNotes;
-            NoteService.addNotes(
-                networkId,
-                address,
-                [
-                    ...createNotes,
-                    ...destroyNotes,
-                    ...updateNotes,
-                ].filter(({ owner }) => owner === address),
-            );
+
             this.saveQueue.push({
                 name: 'Save Notes',
                 groupedNotes,

--- a/packages/extension/src/background/services/EventService/utils/note/createBulkNotes.js
+++ b/packages/extension/src/background/services/EventService/utils/note/createBulkNotes.js
@@ -1,6 +1,31 @@
+import {
+    warnLog,
+} from '~/utils/log';
 import Note from '~/background/database/models/note';
-
+import NoteService from '~/background/services/NoteService';
+import Web3Service from '~/helpers/Web3Service';
 
 export default async function createBulkNotes(notes, networkId) {
-    return Note.bulkAdd(notes, { networkId });
+    let created;
+    try {
+        created = await Note.bulkAdd(notes, { networkId });
+    } catch (e) {
+        // TODO - some of the notes might be valid, create them individually
+        warnLog('Failed to create notes in indexedDB', e);
+        return null;
+    }
+
+    if (created && created.length) {
+        const {
+            address,
+        } = Web3Service.account;
+
+        NoteService.addNotes(
+            networkId,
+            address,
+            notes.filter(({ owner }) => owner === address),
+        );
+    }
+
+    return created;
 }

--- a/packages/extension/src/background/services/EventService/utils/note/createNote.js
+++ b/packages/extension/src/background/services/EventService/utils/note/createNote.js
@@ -1,6 +1,32 @@
+import {
+    warnLog,
+} from '~/utils/log';
 import Note from '~/background/database/models/note';
-
+import NoteService from '~/background/services/NoteService';
+import Web3Service from '~/helpers/Web3Service';
 
 export default async function createNote(note, networkId) {
-    return Note.add(note, { networkId });
+    let newNote;
+    try {
+        newNote = await Note.add(note, { networkId });
+    } catch (e) {
+        warnLog('Failed to create a note in indexedDB', e);
+        return null;
+    }
+
+    if (newNote) {
+        const {
+            address,
+        } = Web3Service.account;
+
+        if (newNote.owner === address) {
+            NoteService.addNotes(
+                networkId,
+                address,
+                [note],
+            );
+        }
+    }
+
+    return newNote;
 }

--- a/packages/extension/src/background/services/EventService/utils/note/updateBulkNotes.js
+++ b/packages/extension/src/background/services/EventService/utils/note/updateBulkNotes.js
@@ -1,6 +1,37 @@
+import {
+    warnLog,
+} from '~/utils/log';
 import Note from '~/background/database/models/note';
-
+import NoteService from '~/background/services/NoteService';
+import Web3Service from '~/helpers/Web3Service';
 
 export default async function updateBulkNotes(notes, networkId) {
-    return Promise.all(notes.map(note => Note.update(note, { networkId })));
+    const updatedIds = await Promise.all(
+        notes.map(async (note) => {
+            let updated;
+            try {
+                updated = await Note.update(note, { networkId });
+            } catch (e) {
+                updated = '';
+                warnLog('Failed to update note in indexedDB', e);
+            }
+            return updated;
+        }),
+    );
+
+    const updatedNotes = notes.filter(note => updatedIds.indexOf(note.id) >= 0);
+
+    if (updatedNotes.length) {
+        const {
+            address,
+        } = Web3Service.account;
+
+        NoteService.addNotes(
+            networkId,
+            address,
+            updatedNotes.filter(({ owner }) => owner === address),
+        );
+    }
+
+    return updatedNotes;
 }

--- a/packages/extension/src/background/services/EventService/utils/note/updateBulkNotes.js
+++ b/packages/extension/src/background/services/EventService/utils/note/updateBulkNotes.js
@@ -6,20 +6,20 @@ import NoteService from '~/background/services/NoteService';
 import Web3Service from '~/helpers/Web3Service';
 
 export default async function updateBulkNotes(notes, networkId) {
-    const updatedIds = await Promise.all(
+    const updatedNotes = [];
+
+    await Promise.all(
         notes.map(async (note) => {
             let updated;
             try {
                 updated = await Note.update(note, { networkId });
+                updatedNotes.push(note);
             } catch (e) {
-                updated = '';
                 warnLog('Failed to update note in indexedDB', e);
             }
             return updated;
         }),
     );
-
-    const updatedNotes = notes.filter(note => updatedIds.indexOf(note.id) >= 0);
 
     if (updatedNotes.length) {
         const {

--- a/packages/extension/src/background/services/EventService/utils/note/updateNote.js
+++ b/packages/extension/src/background/services/EventService/utils/note/updateNote.js
@@ -1,6 +1,30 @@
+import {
+    warnLog,
+} from '~/utils/log';
 import Note from '~/background/database/models/note';
-
+import NoteService from '~/background/services/NoteService';
+import Web3Service from '~/helpers/Web3Service';
 
 export default async function updateNote(note, networkId) {
-    return Note.update(note, { networkId });
+    let updated;
+    try {
+        updated = await Note.update(note, { networkId });
+    } catch (e) {
+        warnLog('Failed to update note in indexedDB', e);
+        return null;
+    }
+
+    if (updated) {
+        const {
+            address,
+        } = Web3Service.account;
+
+        NoteService.addNotes(
+            networkId,
+            address,
+            [note],
+        );
+    }
+
+    return updated;
 }

--- a/packages/extension/src/client/apis/burn/prove.js
+++ b/packages/extension/src/client/apis/burn/prove.js
@@ -1,4 +1,7 @@
-import * as aztec from 'aztec.js';
+import {
+    BurnProof,
+    note as noteUtils,
+} from 'aztec.js';
 import {
     createNote,
     fromViewingKey,
@@ -11,10 +14,6 @@ import ContractError from '~/client/utils/ContractError';
 import ApiError from '~/client/utils/ApiError';
 // import validateExtensionAccount from '../utils/validateExtensionAccount';
 import toAztecNote from '../utils/toAztecNote';
-
-const {
-    BurnProof,
-} = aztec;
 
 export default async function proveBurn({
     assetAddress,
@@ -43,7 +42,7 @@ export default async function proveBurn({
     let balance;
     let oldBurnedCounterNote;
 
-    const zeroNote = await aztec.note.createZeroValueNote();
+    const zeroNote = await noteUtils.createZeroValueNote();
     if (confidentialTotalBurned === zeroNote.noteHash) {
         balance = 0;
         oldBurnedCounterNote = zeroNote;

--- a/packages/extension/src/client/apis/privateRange/prove.js
+++ b/packages/extension/src/client/apis/privateRange/prove.js
@@ -1,4 +1,7 @@
-import * as aztec from 'aztec.js';
+import {
+    PrivateRangeProof,
+    note as noteUtils,
+} from 'aztec.js';
 import {
     createNote,
     valueOf,
@@ -7,10 +10,6 @@ import Web3Service from '~/client/services/Web3Service';
 import ConnectionService from '~/client/services/ConnectionService';
 import ApiError from '~/client/utils/ApiError';
 import toAztecNote from '../utils/toAztecNote';
-
-const {
-    PrivateRangeProof,
-} = aztec;
 
 const valuesValidators = {
     eq: diff => diff === 0,
@@ -61,7 +60,7 @@ export default async function provePrivateRange({
             notesSender.address,
             notesSender.linkedPublicKey,
         );
-    } else if (!(utilityNote instanceof aztec.note.Note)) {
+    } else if (!(utilityNote instanceof noteUtils.Note)) {
         throw new ApiError('input.utilityNote.wrong.type', {
             note: utilityNote,
         });

--- a/packages/extension/src/client/apis/swap/prove.js
+++ b/packages/extension/src/client/apis/swap/prove.js
@@ -1,4 +1,6 @@
-import * as aztec from 'aztec.js';
+import {
+    SwapProof,
+} from 'aztec.js';
 
 export default async function proveSwap({
     swap: {
@@ -9,10 +11,6 @@ export default async function proveSwap({
     },
     sender,
 }) {
-    const {
-        SwapProof,
-    } = aztec;
-
     // const taker = await validateAccount(takerBid.owner, true);
     // const maker = await validateAccount(takerAsk.owner, true);
 

--- a/packages/extension/src/client/apis/utils/toAztecNote.js
+++ b/packages/extension/src/client/apis/utils/toAztecNote.js
@@ -1,7 +1,9 @@
-import * as aztec from 'aztec.js';
+import {
+    note as noteUtils,
+} from 'aztec.js';
 
 export default async function toAztecNote(note) {
-    if (note instanceof aztec.note.Note) {
+    if (note instanceof noteUtils.Note) {
         return note;
     }
     if ('export' in note

--- a/packages/extension/src/ui/apis/asset/deposit.js
+++ b/packages/extension/src/ui/apis/asset/deposit.js
@@ -4,9 +4,9 @@ export default async function deposit({
     currentAccount: {
         address: currentAddress,
     },
+    erc20Amount,
     assetAddress,
     proof,
-    amount,
     isGSNAvailable,
 }) {
     const proofHash = proof.hash;
@@ -20,7 +20,7 @@ export default async function deposit({
             currentAddress,
             proofHash,
             proofData,
-            amount,
+            erc20Amount.toString(),
         ],
     };
 

--- a/packages/extension/src/ui/apis/proof/createNoteFromBalance.js
+++ b/packages/extension/src/ui/apis/proof/createNoteFromBalance.js
@@ -1,4 +1,7 @@
-import * as aztec from 'aztec.js';
+import {
+    JoinSplitProof,
+    ProofUtils,
+} from 'aztec.js';
 import { keccak256 } from 'web3-utils';
 import {
     METADATA_AZTEC_DATA_LENGTH,
@@ -179,10 +182,6 @@ export default async function createNoteFromBalance({
         });
     }
 
-    const {
-        JoinSplitProof,
-        ProofUtils,
-    } = aztec;
     const publicValue = ProofUtils.getPublicValue(
         inputValues,
         outputValues,

--- a/packages/extension/src/ui/apis/proof/deposit.js
+++ b/packages/extension/src/ui/apis/proof/deposit.js
@@ -1,4 +1,7 @@
-import * as aztec from 'aztec.js';
+import {
+    JoinSplitProof,
+    ProofUtils,
+} from 'aztec.js';
 import {
     randomSumArray,
 } from '~/utils/random';
@@ -9,11 +12,6 @@ import settings from '~/background/utils/settings';
 import {
     batchGetExtensionAccount,
 } from '~/ui/apis/account';
-
-const {
-    JoinSplitProof,
-    ProofUtils,
-} = aztec;
 
 export default async function deposit({
     transactions,

--- a/packages/extension/src/ui/locales/en/note.js
+++ b/packages/extension/src/ui/locales/en/note.js
@@ -18,12 +18,12 @@ export default {
             title: 'Grant Access',
             step: 'Granting Access',
             description: `This will grant another user view access to a portion of your balance.
-                It will not allow the ZkTokens to be spent without a signature from your MetaMask account.
+                It will not allow the zkTokens to be spent without a signature from your MetaMask account.
             `,
             submit: 'Grant Access',
         },
         sign: {
-            description: `A MetaMask signature is required to grant access to ZkTokens.
+            description: `A MetaMask signature is required to grant access to zkTokens.
                 The signature should contain the following values:
             `,
         },

--- a/packages/extension/src/ui/locales/en/send.js
+++ b/packages/extension/src/ui/locales/en/send.js
@@ -1,7 +1,7 @@
 export default {
-    title: 'Send ZkTokens',
+    title: 'Send zkTokens',
     approve: {
-        description: `A signature is required to send ZkTokens.
+        description: `A signature is required to send zkTokens.
             The SDK will pick the most suitable notes for the transaction.
             Check the transaction details are correct before proceeding.
         `,
@@ -9,7 +9,7 @@ export default {
     },
     approved: 'Approved',
     sign: {
-        description: `A MetaMask signature is required to send ZkTokens.
+        description: `A MetaMask signature is required to send zkTokens.
             The signature should contain the following values:
         `,
     },
@@ -19,7 +19,7 @@ export default {
         `,
     },
     send: {
-        step: 'Sending ZkTokens',
+        step: 'Sending zkTokens',
         description: `The SDK has picked the most suitable notes for this transaction.
             If everything looks good hit send!
         `,

--- a/packages/extension/src/ui/locales/en/withdraw.js
+++ b/packages/extension/src/ui/locales/en/withdraw.js
@@ -1,7 +1,7 @@
 export default {
-    title: 'Withdraw ZkTokens',
+    title: 'Withdraw zkTokens',
     approve: {
-        description: `A signature is required to withdraw ZkTokens.
+        description: `A signature is required to withdraw zkTokens.
             The SDK will pick the most suitable notes for the transaction.
             Check the transaction details are correct before proceeding.
         `,
@@ -9,7 +9,7 @@ export default {
         submit: 'Approve Withdraw',
     },
     sign: {
-        description: `A MetaMask signature is required to withdraw ZkTokens.
+        description: `A MetaMask signature is required to withdraw zkTokens.
             The signature should contain the following values:
         `,
     },
@@ -19,7 +19,7 @@ export default {
         `,
     },
     send: {
-        step: 'Withdrawing ZkTokens',
+        step: 'Withdrawing zkTokens',
         description: `The SDK has picked the most suitable notes for this transaction.
             If everything looks good hit send!
         `,

--- a/packages/extension/src/ui/pages/Deposit.jsx
+++ b/packages/extension/src/ui/pages/Deposit.jsx
@@ -59,7 +59,8 @@ const Deposit = ({
                 allowanceSpender,
             );
         const approvedERC20Allowance = new BN(allowance);
-        const requestedAllowance = asset.scalingFactor.mul(new BN(amount));
+        const erc20Amount = asset.scalingFactor.mul(new BN(amount));
+        const requestedAllowance = erc20Amount;
         if (approvedERC20Allowance.gte(requestedAllowance)) {
             steps = steps.filter(({ name }) => name !== 'approveERC20');
         }
@@ -74,11 +75,11 @@ const Deposit = ({
             sender,
             spender: sender,
             amount,
-            numberOfOutputNotes,
-            userAccessAccounts,
+            erc20Amount,
             requestedAllowance,
             allowanceSpender,
-            spenderName: 'AZTEC',
+            numberOfOutputNotes,
+            userAccessAccounts,
             isGSNAvailable,
         };
     };

--- a/packages/extension/src/utils/format/capitalize.js
+++ b/packages/extension/src/utils/format/capitalize.js
@@ -3,5 +3,9 @@ export default function capitalize(str) {
         return '';
     }
 
+    if (str.match(/^[a-z]{0,}[A-Z]/)) {
+        return str;
+    }
+
     return `${str[0].toUpperCase()}${str.slice(1)}`;
 }

--- a/packages/extension/src/utils/note/createNote.js
+++ b/packages/extension/src/utils/note/createNote.js
@@ -1,4 +1,6 @@
-import * as aztec from 'aztec.js';
+import {
+    note as noteUtils,
+} from 'aztec.js';
 
 export default async function createNote(value, publicKey, owner, access) {
     let accessArr;
@@ -16,5 +18,5 @@ export default async function createNote(value, publicKey, owner, access) {
         }
     }
 
-    return aztec.note.create(publicKey, value, accessArr, owner);
+    return noteUtils.create(publicKey, value, accessArr, owner);
 }

--- a/packages/extension/src/utils/note/fromViewingKey.js
+++ b/packages/extension/src/utils/note/fromViewingKey.js
@@ -1,7 +1,9 @@
-import * as aztec from 'aztec.js';
+import {
+    note as noteUtils,
+} from 'aztec.js';
 
 export default async function fromViewingKey(viewingKey, owner) {
-    const note = await aztec.note.fromViewKey(viewingKey);
+    const note = await noteUtils.fromViewKey(viewingKey);
     if (note && owner) {
         note.owner = owner;
     }


### PR DESCRIPTION
## Summary

The major fix in this PR is for EventService:
- the event subscription sometimes returns duplicated results and therefor doubled the asset balance. After this fix, a new note's value is added to the balance only when it is not in indexedDB.

Other minor fixes:
- use named import for aztec.js to tree-shake unused utils
- send correct deposit value multiplied by scaling factor to account registry contract
- change ZkAsset and ZkToken to zkAsset and zkToken

## Types of changes

Bug fix (non-breaking change which fixes an issue)
