### PR TITLE
Feat upgrade gas price

### DIFF
--- a/packages/extension/src/utils/Web3Service.js
+++ b/packages/extension/src/utils/Web3Service.js
@@ -374,7 +374,7 @@ class Web3Service {
                                     method: gsnContract.methods[methodName],
                                     fromAddress: signingInfo.address,
                                     args,
-                                    gasPrice: gasPrice ? gasPrice * 1.3 : 18000000000, // set gas price 30% higher than last few blocks median to ensure we get in the block
+                                    gasPrice: gasPrice ? gasPrice * 2 : 18000000000, // set gas price 100% higher than last few blocks median to ensure we get in the block
                                     web3,
                                 });
                             },


### PR DESCRIPTION
## Summary

Transactions on mainnet are taking too long to confirm due the default gas price being set on the GSN.

## Description

This PR bumps the gas price to 2x the median gas price of the last few blocks.

## Types of changes

Bug fix (non-breaking change which fixes an issue) 
