### PR TITLE
Commit updated yarn.lock

### DIFF
--- a/packages/integration-test/src/setup.js
+++ b/packages/integration-test/src/setup.js
@@ -105,7 +105,12 @@ class Setup {
     /**
      * @method getContractPromise - get an object whose key is the name of a contract, and the value is a function that
      * returns the Truffle representation of the contract
-     * @param {string} nameOfContract
+     * @param {string} nameOfContract - name of the contract for which the contract promise should be generated
+     * @param {string} address - (optional) address at which the contract should be instantiated. Can be supplied to override the
+     * default address used, whereby the default is the address associated with the `nameOfContract`.
+     *
+     * An example of where `address` will be supplied is when generating a deployed proxy contract. In this case the address will be
+     * the address of the proxy, whilst `nameOfContract` will be the behaviour implementation the address is cast with.
      */
     getContractPromise(nameOfContract, address = null) {
         const extractedContractArtifact = contractArtifacts[nameOfContract];

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,11 +232,6 @@
   dependencies:
     lodash "^4.17.11"
 
-"@aztec/contract-artifacts@1.18.0":
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/@aztec/contract-artifacts/-/contract-artifacts-1.18.0.tgz#38c94f0217a97d4232fb9ae4d2d01cfd57cd389f"
-  integrity sha512-FA0QIVGZKDkMe4dDmZRRirl0cXhfhBydlUaCt24Zx+bGSTeuT9wpPfp0K5HfILTD8tZ7YYGlx4cc4yw3x/RP1w==
-
 "@aztec/guacamole-ui@1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@aztec/guacamole-ui/-/guacamole-ui-1.1.3.tgz#df43b350842a0e3239ab30528217bd56ba6deac9"
@@ -23508,7 +23503,6 @@ websocket@^1.0.28:
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
-    gulp "^4.0.2"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"


### PR DESCRIPTION
## Summary
This PR commits the updated `yarn.lock`, to avoid a diff being generated in the build pipeline when `yarn install` is run - and so prevent needless `contract-artifacts` redeploy. 

It also adds a minor missing JsDoc comment in the `integration-test` `setup` script.
