### PR TITLE
Add `AccountRegistry` support for DAI `permit()` function

### DIFF
--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -53,7 +53,6 @@ signer.generateZKAssetDomainParams = (verifyingContract) => {
     };
 };
 
-
 /**
  * Generate EIP712 domain parameters for DAI token
  * @method generateDAIDomainParams
@@ -64,8 +63,7 @@ signer.generateDAIDomainParams = (chainId, verifyingContract) => {
         ...constants.eip712.DAI_DOMAIN_PARAMS,
         chainId,
         verifyingContract,
-    }
-
+    };
 };
 
 /**
@@ -220,7 +218,7 @@ signer.signNoteACEDomain = (verifyingContract, spender, privateKey) => {
 /**
  * Allows a user to create a signature for use in the DAI.permit() function. Creates an EIP712 ECDSA
  * signature
- * 
+ *
  * @method signPermit
  * @param {Object} holderAccount - address that owns the tokens, which is approving a spender to spend
  * @param {Address} spender - address being approved to spend the tokens

--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -203,6 +203,34 @@ signer.signNoteACEDomain = (verifyingContract, spender, privateKey) => {
 };
 
 /**
+ * Allows a user to create a signature for use in the DAI.permit() function. Creates an EIP712 ECDSA
+ * signature
+ * 
+ * @method signPermit
+ * @param {Object} holderAccount - address that owns the tokens, which is approving a spender to spend
+ * @param {Address} spender - address being approved to spend the tokens
+ * @param {Number} nonce - nonce of the transaction. Used for replay protection in the DAI token contract
+ * @param {Number} expiry - unix timestamp corresponding to the upper boundary for when the permit is valid
+ * @param {Bool} allowed - whether approval is being granted or revoked
+ */
+signer.signPermit = (verifyingContract, holderAccount, spender, nonce, expiry, allowed) => {
+    const { address: holder, privateKey } = holderAccount;
+    const domain = signer.generateAccountRegistryDomainParams(verifyingContract);
+    const schema = constants.eip712.PERMIT_SIGNATURE;
+
+    const message = {
+        holder,
+        spender,
+        nonce,
+        expiry,
+        allowed,
+    };
+
+    const { unformattedSignature } = signer.signTypedData(domain, schema, message, privateKey);
+    return `0x${unformattedSignature.slice(0, 130)}`;
+};
+
+/**
  * Create an EIP712 ECDSA signature over structured data. This is a low level function that returns the signature parameters
  * in an unstructured form - `r`, `s` and `v` are all 32 bytes in size.
  *

--- a/packages/aztec.js/src/signer/index.js
+++ b/packages/aztec.js/src/signer/index.js
@@ -53,6 +53,21 @@ signer.generateZKAssetDomainParams = (verifyingContract) => {
     };
 };
 
+
+/**
+ * Generate EIP712 domain parameters for DAI token
+ * @method generateDAIDomainParams
+ * @param
+ */
+signer.generateDAIDomainParams = (chainId, verifyingContract) => {
+    return {
+        ...constants.eip712.DAI_DOMAIN_PARAMS,
+        chainId,
+        verifyingContract,
+    }
+
+};
+
 /**
  * Create an EIP712 ECDSA signature over an AZTEC note, suited for the confidentialApprove() method of a
  * ZkAsset. The ZkAsset.confidentialApprove() method must be called when granting note spending permission
@@ -213,9 +228,9 @@ signer.signNoteACEDomain = (verifyingContract, spender, privateKey) => {
  * @param {Number} expiry - unix timestamp corresponding to the upper boundary for when the permit is valid
  * @param {Bool} allowed - whether approval is being granted or revoked
  */
-signer.signPermit = (verifyingContract, holderAccount, spender, nonce, expiry, allowed) => {
+signer.signPermit = (chainId, verifyingContract, holderAccount, spender, nonce, expiry, allowed) => {
     const { address: holder, privateKey } = holderAccount;
-    const domain = signer.generateAccountRegistryDomainParams(verifyingContract);
+    const domain = signer.generateDAIDomainParams(chainId, verifyingContract);
     const schema = constants.eip712.PERMIT_SIGNATURE;
 
     const message = {

--- a/packages/aztec.js/test/signer/index.js
+++ b/packages/aztec.js/test/signer/index.js
@@ -278,7 +278,6 @@ describe('Signer', () => {
                 aztecAccount.privateKey,
             );
 
-
             const domain = signer.generateZKAssetDomainParams(verifyingContract);
             const { types, primaryType } = constants.eip712.PROOF_SIGNATURE;
             const metaMaskTypedData = {

--- a/packages/aztec.js/test/signer/index.js
+++ b/packages/aztec.js/test/signer/index.js
@@ -235,25 +235,12 @@ describe('Signer', () => {
             const testNoteValue = 10;
             const testNote = await note.create(aztecAccount.publicKey, testNoteValue);
 
+            const domain = signer.generateZKAssetDomainParams(verifyingContract);
+            const { types, primaryType } = constants.eip712.NOTE_SIGNATURE;
             const metaMaskTypedData = {
-                domain: {
-                    name: 'ZK_ASSET',
-                    version: '1',
-                    verifyingContract,
-                },
-                types: {
-                    NoteSignature: [
-                        { name: 'noteHash', type: 'bytes32' },
-                        { name: 'spender', type: 'address' },
-                        { name: 'spenderApproval', type: 'bool' },
-                    ],
-                    EIP712Domain: [
-                        { name: 'name', type: 'string' },
-                        { name: 'version', type: 'string' },
-                        { name: 'verifyingContract', type: 'address' },
-                    ],
-                },
-                primaryType: 'NoteSignature',
+                domain,
+                types,
+                primaryType,
                 message: {
                     noteHash: testNote.noteHash,
                     spender,
@@ -280,8 +267,8 @@ describe('Signer', () => {
             const aztecAccount = secp256k1.generateAccount();
             const spender = randomHex(20);
             const verifyingContract = randomHex(20);
-
             const joinSplitProof = randomHex(20);
+            const proofHash = keccak256(joinSplitProof);
 
             const aztecSignature = signer.signApprovalForProof(
                 verifyingContract,
@@ -291,41 +278,54 @@ describe('Signer', () => {
                 aztecAccount.privateKey,
             );
 
-            const proofHash = keccak256(joinSplitProof);
 
-            const message = {
-                proofHash,
-                spender,
-                approval: true,
-            };
-
+            const domain = signer.generateZKAssetDomainParams(verifyingContract);
+            const { types, primaryType } = constants.eip712.PROOF_SIGNATURE;
             const metaMaskTypedData = {
-                domain: {
-                    name: 'ZK_ASSET',
-                    version: '1',
-                    verifyingContract,
+                domain,
+                types,
+                primaryType,
+                message: {
+                    proofHash,
+                    spender,
+                    approval: true,
                 },
-                types: {
-                    ProofSignature: [
-                        { name: 'proofHash', type: 'bytes32' },
-                        { name: 'spender', type: 'address' },
-                        { name: 'approval', type: 'bool' },
-                    ],
-                    EIP712Domain: [
-                        { name: 'name', type: 'string' },
-                        { name: 'version', type: 'string' },
-                        { name: 'verifyingContract', type: 'address' },
-                    ],
-                },
-                primaryType: 'ProofSignature',
-                message,
             };
 
             // eth-sig-util is the MetaMask signing package
             const metaMaskSignature = ethSigUtil.signTypedData_v4(Buffer.from(aztecAccount.privateKey.slice(2), 'hex'), {
                 data: metaMaskTypedData,
             });
+            expect(aztecSignature).to.equal(metaMaskSignature);
+        });
 
+        it('signPermit() should produce same signature as MetaMask signing function', async () => {
+            const verifyingContract = randomHex(20);
+            const holderAccount = secp256k1.generateAccount();
+            const spender = randomHex(20);
+            const nonce = 5;
+            const expiry = 10;
+            const allowed = true;
+            const aztecSignature = signer.signPermit(verifyingContract, holderAccount, spender, nonce, expiry, allowed);
+
+            const domain = signer.generateAccountRegistryDomainParams(verifyingContract);
+            const { types, primaryType } = constants.eip712.PERMIT_SIGNATURE;
+            const metaMaskTypedData = {
+                domain,
+                types,
+                primaryType,
+                message: {
+                    holder: holderAccount.address,
+                    spender,
+                    nonce,
+                    expiry,
+                    allowed,
+                },
+            };
+            // eth-sig-util is the MetaMask signing package
+            const metaMaskSignature = ethSigUtil.signTypedData_v4(Buffer.from(holderAccount.privateKey.slice(2), 'hex'), {
+                data: metaMaskTypedData,
+            });
             expect(aztecSignature).to.equal(metaMaskSignature);
         });
     });

--- a/packages/aztec.js/test/signer/index.js
+++ b/packages/aztec.js/test/signer/index.js
@@ -306,9 +306,10 @@ describe('Signer', () => {
             const nonce = 5;
             const expiry = 10;
             const allowed = true;
-            const aztecSignature = signer.signPermit(verifyingContract, holderAccount, spender, nonce, expiry, allowed);
+            const chainId = 4;
+            const aztecSignature = signer.signPermit(chainId, verifyingContract, holderAccount, spender, nonce, expiry, allowed);
 
-            const domain = signer.generateAccountRegistryDomainParams(verifyingContract);
+            const domain = signer.generateDAIDomainParams(chainId, verifyingContract);
             const { types, primaryType } = constants.eip712.PERMIT_SIGNATURE;
             const metaMaskTypedData = {
                 domain,

--- a/packages/contract-artifacts/artifacts/IERC20Permit.json
+++ b/packages/contract-artifacts/artifacts/IERC20Permit.json
@@ -1,0 +1,2773 @@
+{
+    "contractName": "IERC20Permit",
+    "abi": [
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "Approval",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+          },
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "Transfer",
+        "type": "event"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "name": "nonces",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transfer",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "approve",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transferFrom",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "holder",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "expiry",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "allowed",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint8",
+            "name": "v",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "r",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "s",
+            "type": "bytes32"
+          }
+        ],
+        "name": "permit",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": false,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "_value",
+            "type": "uint256"
+          }
+        ],
+        "name": "mint",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [],
+        "name": "totalSupply",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "who",
+            "type": "address"
+          }
+        ],
+        "name": "balanceOf",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          }
+        ],
+        "name": "allowance",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      }
+    ],
+    "metadata": "{\"compiler\":{\"version\":\"0.5.16+commit.9c3226ce\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"constant\":true,\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"internalType\":\"address\",\"name\":\"who\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"_to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_value\",\"type\":\"uint256\"}],\"name\":\"mint\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"nonces\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"holder\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"allowed\",\"type\":\"bool\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"details\":\"Interface for ERC20 with minting function Sourced from OpenZeppelin  (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC20/IERC20.sol)  and with an added permit() and mint() function. \",\"methods\":{},\"title\":\"IERC20Permit\"},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"/Users/thomaswaite/Documents/AZTEC/Code/aztec/AZTEC/packages/protocol/contracts/interfaces/IERC20Permit.sol\":\"IERC20Permit\"},\"evmVersion\":\"petersburg\",\"libraries\":{},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"/Users/thomaswaite/Documents/AZTEC/Code/aztec/AZTEC/packages/protocol/contracts/interfaces/IERC20Permit.sol\":{\"keccak256\":\"0x716d2d602413f10f8c97d326a83f328701449e96e126af72cf9e1ff58b775557\",\"urls\":[\"bzz-raw://1f8353b74167dc12c09b69bd2fd6acf2902f330b95febe1c6ab6e4a1e4076ae8\",\"dweb:/ipfs/QmXVyzuHb2MYNuNuudqu5X6zS6W2mPdwABqxx65E9SCX9y\"]}},\"version\":1}",
+    "bytecode": "0x",
+    "deployedBytecode": "0x",
+    "sourceMap": "",
+    "deployedSourceMap": "",
+    "source": "pragma solidity >=0.5.0 <0.6.0;\n\n\n/**\n * @title IERC20Permit\n * @dev Interface for ERC20 with minting function\n * Sourced from OpenZeppelin \n * (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC20/IERC20.sol) \n * and with an added permit() and mint() function. \n */\ncontract IERC20Permit {\n\n    mapping (address => uint)                      public nonces;\n    function transfer(address to, uint256 value) external returns (bool);\n\n    function approve(address spender, uint256 value) external returns (bool);\n\n    function transferFrom(address from, address to, uint256 value) external returns (bool);\n    \n    function permit(\n        address holder,\n        address spender,\n        uint256 nonce,\n        uint256 expiry,\n        bool allowed,\n        uint8 v,\n        bytes32 r,\n        bytes32 s\n    ) external;   \n\n    function mint(address _to, uint256 _value) external returns (bool);   \n\n    function totalSupply() external view returns (uint256);\n\n    function balanceOf(address who) external view returns (uint256);\n\n    function allowance(address owner, address spender) external view returns (uint256);\n\n    event Transfer(address indexed from, address indexed to, uint256 value);\n\n    event Approval(address indexed owner, address indexed spender, uint256 value);\n}\n",
+    "sourcePath": "/Users/thomaswaite/Documents/AZTEC/Code/aztec/AZTEC/packages/protocol/contracts/interfaces/IERC20Permit.sol",
+    "ast": {
+      "absolutePath": "/Users/thomaswaite/Documents/AZTEC/Code/aztec/AZTEC/packages/protocol/contracts/interfaces/IERC20Permit.sol",
+      "exportedSymbols": {
+        "IERC20Permit": [
+          8607
+        ]
+      },
+      "id": 8608,
+      "nodeType": "SourceUnit",
+      "nodes": [
+        {
+          "id": 8508,
+          "literals": [
+            "solidity",
+            ">=",
+            "0.5",
+            ".0",
+            "<",
+            "0.6",
+            ".0"
+          ],
+          "nodeType": "PragmaDirective",
+          "src": "0:31:62"
+        },
+        {
+          "baseContracts": [],
+          "contractDependencies": [],
+          "contractKind": "contract",
+          "documentation": "@title IERC20Permit\n@dev Interface for ERC20 with minting function\nSourced from OpenZeppelin \n(https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC20/IERC20.sol) \nand with an added permit() and mint() function. ",
+          "fullyImplemented": false,
+          "id": 8607,
+          "linearizedBaseContracts": [
+            8607
+          ],
+          "name": "IERC20Permit",
+          "nodeType": "ContractDefinition",
+          "nodes": [
+            {
+              "constant": false,
+              "id": 8512,
+              "name": "nonces",
+              "nodeType": "VariableDeclaration",
+              "scope": 8607,
+              "src": "331:60:62",
+              "stateVariable": true,
+              "storageLocation": "default",
+              "typeDescriptions": {
+                "typeIdentifier": "t_mapping$_t_address_$_t_uint256_$",
+                "typeString": "mapping(address => uint256)"
+              },
+              "typeName": {
+                "id": 8511,
+                "keyType": {
+                  "id": 8509,
+                  "name": "address",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "340:7:62",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  }
+                },
+                "nodeType": "Mapping",
+                "src": "331:25:62",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_mapping$_t_address_$_t_uint256_$",
+                  "typeString": "mapping(address => uint256)"
+                },
+                "valueType": {
+                  "id": 8510,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "351:4:62",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  }
+                }
+              },
+              "value": null,
+              "visibility": "public"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8521,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "transfer",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8517,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8514,
+                    "name": "to",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8521,
+                    "src": "415:10:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8513,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "415:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8516,
+                    "name": "value",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8521,
+                    "src": "427:13:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8515,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "427:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "414:27:62"
+              },
+              "returnParameters": {
+                "id": 8520,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8519,
+                    "name": "",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8521,
+                    "src": "460:4:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    },
+                    "typeName": {
+                      "id": 8518,
+                      "name": "bool",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "460:4:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "459:6:62"
+              },
+              "scope": 8607,
+              "src": "397:69:62",
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8530,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "approve",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8526,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8523,
+                    "name": "spender",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8530,
+                    "src": "489:15:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8522,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "489:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8525,
+                    "name": "value",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8530,
+                    "src": "506:13:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8524,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "506:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "488:32:62"
+              },
+              "returnParameters": {
+                "id": 8529,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8528,
+                    "name": "",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8530,
+                    "src": "539:4:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    },
+                    "typeName": {
+                      "id": 8527,
+                      "name": "bool",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "539:4:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "538:6:62"
+              },
+              "scope": 8607,
+              "src": "472:73:62",
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8541,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "transferFrom",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8537,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8532,
+                    "name": "from",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8541,
+                    "src": "573:12:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8531,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "573:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8534,
+                    "name": "to",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8541,
+                    "src": "587:10:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8533,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "587:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8536,
+                    "name": "value",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8541,
+                    "src": "599:13:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8535,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "599:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "572:41:62"
+              },
+              "returnParameters": {
+                "id": 8540,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8539,
+                    "name": "",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8541,
+                    "src": "632:4:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    },
+                    "typeName": {
+                      "id": 8538,
+                      "name": "bool",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "632:4:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "631:6:62"
+              },
+              "scope": 8607,
+              "src": "551:87:62",
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8560,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "permit",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8558,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8543,
+                    "name": "holder",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "673:14:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8542,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "673:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8545,
+                    "name": "spender",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "697:15:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8544,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "697:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8547,
+                    "name": "nonce",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "722:13:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8546,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "722:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8549,
+                    "name": "expiry",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "745:14:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8548,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "745:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8551,
+                    "name": "allowed",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "769:12:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    },
+                    "typeName": {
+                      "id": 8550,
+                      "name": "bool",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "769:4:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8553,
+                    "name": "v",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "791:7:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint8",
+                      "typeString": "uint8"
+                    },
+                    "typeName": {
+                      "id": 8552,
+                      "name": "uint8",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "791:5:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint8",
+                        "typeString": "uint8"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8555,
+                    "name": "r",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "808:9:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    },
+                    "typeName": {
+                      "id": 8554,
+                      "name": "bytes32",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "808:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bytes32",
+                        "typeString": "bytes32"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8557,
+                    "name": "s",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "827:9:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    },
+                    "typeName": {
+                      "id": 8556,
+                      "name": "bytes32",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "827:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bytes32",
+                        "typeString": "bytes32"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "663:179:62"
+              },
+              "returnParameters": {
+                "id": 8559,
+                "nodeType": "ParameterList",
+                "parameters": [],
+                "src": "851:0:62"
+              },
+              "scope": 8607,
+              "src": "648:204:62",
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8569,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "mint",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8565,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8562,
+                    "name": "_to",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8569,
+                    "src": "875:11:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8561,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "875:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8564,
+                    "name": "_value",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8569,
+                    "src": "888:14:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8563,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "888:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "874:29:62"
+              },
+              "returnParameters": {
+                "id": 8568,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8567,
+                    "name": "",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8569,
+                    "src": "922:4:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    },
+                    "typeName": {
+                      "id": 8566,
+                      "name": "bool",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "922:4:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "921:6:62"
+              },
+              "scope": 8607,
+              "src": "861:67:62",
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8574,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "totalSupply",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8570,
+                "nodeType": "ParameterList",
+                "parameters": [],
+                "src": "957:2:62"
+              },
+              "returnParameters": {
+                "id": 8573,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8572,
+                    "name": "",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8574,
+                    "src": "983:7:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8571,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "983:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "982:9:62"
+              },
+              "scope": 8607,
+              "src": "937:55:62",
+              "stateMutability": "view",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8581,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "balanceOf",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8577,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8576,
+                    "name": "who",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8581,
+                    "src": "1017:11:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8575,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1017:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "1016:13:62"
+              },
+              "returnParameters": {
+                "id": 8580,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8579,
+                    "name": "",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8581,
+                    "src": "1053:7:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8578,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1053:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "1052:9:62"
+              },
+              "scope": 8607,
+              "src": "998:64:62",
+              "stateMutability": "view",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8590,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "allowance",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8586,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8583,
+                    "name": "owner",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8590,
+                    "src": "1087:13:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8582,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1087:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8585,
+                    "name": "spender",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8590,
+                    "src": "1102:15:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8584,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1102:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "1086:32:62"
+              },
+              "returnParameters": {
+                "id": 8589,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8588,
+                    "name": "",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8590,
+                    "src": "1142:7:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8587,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1142:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "1141:9:62"
+              },
+              "scope": 8607,
+              "src": "1068:83:62",
+              "stateMutability": "view",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "anonymous": false,
+              "documentation": null,
+              "id": 8598,
+              "name": "Transfer",
+              "nodeType": "EventDefinition",
+              "parameters": {
+                "id": 8597,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8592,
+                    "indexed": true,
+                    "name": "from",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8598,
+                    "src": "1172:20:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8591,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1172:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8594,
+                    "indexed": true,
+                    "name": "to",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8598,
+                    "src": "1194:18:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8593,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1194:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8596,
+                    "indexed": false,
+                    "name": "value",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8598,
+                    "src": "1214:13:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8595,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1214:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "1171:57:62"
+              },
+              "src": "1157:72:62"
+            },
+            {
+              "anonymous": false,
+              "documentation": null,
+              "id": 8606,
+              "name": "Approval",
+              "nodeType": "EventDefinition",
+              "parameters": {
+                "id": 8605,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8600,
+                    "indexed": true,
+                    "name": "owner",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8606,
+                    "src": "1250:21:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8599,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1250:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8602,
+                    "indexed": true,
+                    "name": "spender",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8606,
+                    "src": "1273:23:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8601,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1273:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8604,
+                    "indexed": false,
+                    "name": "value",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8606,
+                    "src": "1298:13:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8603,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1298:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "1249:63:62"
+              },
+              "src": "1235:78:62"
+            }
+          ],
+          "scope": 8608,
+          "src": "302:1013:62"
+        }
+      ],
+      "src": "0:1316:62"
+    },
+    "legacyAST": {
+      "absolutePath": "/Users/thomaswaite/Documents/AZTEC/Code/aztec/AZTEC/packages/protocol/contracts/interfaces/IERC20Permit.sol",
+      "exportedSymbols": {
+        "IERC20Permit": [
+          8607
+        ]
+      },
+      "id": 8608,
+      "nodeType": "SourceUnit",
+      "nodes": [
+        {
+          "id": 8508,
+          "literals": [
+            "solidity",
+            ">=",
+            "0.5",
+            ".0",
+            "<",
+            "0.6",
+            ".0"
+          ],
+          "nodeType": "PragmaDirective",
+          "src": "0:31:62"
+        },
+        {
+          "baseContracts": [],
+          "contractDependencies": [],
+          "contractKind": "contract",
+          "documentation": "@title IERC20Permit\n@dev Interface for ERC20 with minting function\nSourced from OpenZeppelin \n(https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC20/IERC20.sol) \nand with an added permit() and mint() function. ",
+          "fullyImplemented": false,
+          "id": 8607,
+          "linearizedBaseContracts": [
+            8607
+          ],
+          "name": "IERC20Permit",
+          "nodeType": "ContractDefinition",
+          "nodes": [
+            {
+              "constant": false,
+              "id": 8512,
+              "name": "nonces",
+              "nodeType": "VariableDeclaration",
+              "scope": 8607,
+              "src": "331:60:62",
+              "stateVariable": true,
+              "storageLocation": "default",
+              "typeDescriptions": {
+                "typeIdentifier": "t_mapping$_t_address_$_t_uint256_$",
+                "typeString": "mapping(address => uint256)"
+              },
+              "typeName": {
+                "id": 8511,
+                "keyType": {
+                  "id": 8509,
+                  "name": "address",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "340:7:62",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  }
+                },
+                "nodeType": "Mapping",
+                "src": "331:25:62",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_mapping$_t_address_$_t_uint256_$",
+                  "typeString": "mapping(address => uint256)"
+                },
+                "valueType": {
+                  "id": 8510,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "351:4:62",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  }
+                }
+              },
+              "value": null,
+              "visibility": "public"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8521,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "transfer",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8517,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8514,
+                    "name": "to",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8521,
+                    "src": "415:10:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8513,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "415:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8516,
+                    "name": "value",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8521,
+                    "src": "427:13:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8515,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "427:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "414:27:62"
+              },
+              "returnParameters": {
+                "id": 8520,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8519,
+                    "name": "",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8521,
+                    "src": "460:4:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    },
+                    "typeName": {
+                      "id": 8518,
+                      "name": "bool",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "460:4:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "459:6:62"
+              },
+              "scope": 8607,
+              "src": "397:69:62",
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8530,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "approve",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8526,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8523,
+                    "name": "spender",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8530,
+                    "src": "489:15:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8522,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "489:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8525,
+                    "name": "value",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8530,
+                    "src": "506:13:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8524,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "506:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "488:32:62"
+              },
+              "returnParameters": {
+                "id": 8529,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8528,
+                    "name": "",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8530,
+                    "src": "539:4:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    },
+                    "typeName": {
+                      "id": 8527,
+                      "name": "bool",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "539:4:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "538:6:62"
+              },
+              "scope": 8607,
+              "src": "472:73:62",
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8541,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "transferFrom",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8537,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8532,
+                    "name": "from",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8541,
+                    "src": "573:12:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8531,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "573:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8534,
+                    "name": "to",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8541,
+                    "src": "587:10:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8533,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "587:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8536,
+                    "name": "value",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8541,
+                    "src": "599:13:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8535,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "599:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "572:41:62"
+              },
+              "returnParameters": {
+                "id": 8540,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8539,
+                    "name": "",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8541,
+                    "src": "632:4:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    },
+                    "typeName": {
+                      "id": 8538,
+                      "name": "bool",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "632:4:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "631:6:62"
+              },
+              "scope": 8607,
+              "src": "551:87:62",
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8560,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "permit",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8558,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8543,
+                    "name": "holder",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "673:14:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8542,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "673:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8545,
+                    "name": "spender",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "697:15:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8544,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "697:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8547,
+                    "name": "nonce",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "722:13:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8546,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "722:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8549,
+                    "name": "expiry",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "745:14:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8548,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "745:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8551,
+                    "name": "allowed",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "769:12:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    },
+                    "typeName": {
+                      "id": 8550,
+                      "name": "bool",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "769:4:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8553,
+                    "name": "v",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "791:7:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint8",
+                      "typeString": "uint8"
+                    },
+                    "typeName": {
+                      "id": 8552,
+                      "name": "uint8",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "791:5:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint8",
+                        "typeString": "uint8"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8555,
+                    "name": "r",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "808:9:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    },
+                    "typeName": {
+                      "id": 8554,
+                      "name": "bytes32",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "808:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bytes32",
+                        "typeString": "bytes32"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8557,
+                    "name": "s",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8560,
+                    "src": "827:9:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    },
+                    "typeName": {
+                      "id": 8556,
+                      "name": "bytes32",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "827:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bytes32",
+                        "typeString": "bytes32"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "663:179:62"
+              },
+              "returnParameters": {
+                "id": 8559,
+                "nodeType": "ParameterList",
+                "parameters": [],
+                "src": "851:0:62"
+              },
+              "scope": 8607,
+              "src": "648:204:62",
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8569,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "mint",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8565,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8562,
+                    "name": "_to",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8569,
+                    "src": "875:11:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8561,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "875:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8564,
+                    "name": "_value",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8569,
+                    "src": "888:14:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8563,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "888:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "874:29:62"
+              },
+              "returnParameters": {
+                "id": 8568,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8567,
+                    "name": "",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8569,
+                    "src": "922:4:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    },
+                    "typeName": {
+                      "id": 8566,
+                      "name": "bool",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "922:4:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "921:6:62"
+              },
+              "scope": 8607,
+              "src": "861:67:62",
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8574,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "totalSupply",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8570,
+                "nodeType": "ParameterList",
+                "parameters": [],
+                "src": "957:2:62"
+              },
+              "returnParameters": {
+                "id": 8573,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8572,
+                    "name": "",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8574,
+                    "src": "983:7:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8571,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "983:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "982:9:62"
+              },
+              "scope": 8607,
+              "src": "937:55:62",
+              "stateMutability": "view",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8581,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "balanceOf",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8577,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8576,
+                    "name": "who",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8581,
+                    "src": "1017:11:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8575,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1017:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "1016:13:62"
+              },
+              "returnParameters": {
+                "id": 8580,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8579,
+                    "name": "",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8581,
+                    "src": "1053:7:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8578,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1053:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "1052:9:62"
+              },
+              "scope": 8607,
+              "src": "998:64:62",
+              "stateMutability": "view",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "body": null,
+              "documentation": null,
+              "id": 8590,
+              "implemented": false,
+              "kind": "function",
+              "modifiers": [],
+              "name": "allowance",
+              "nodeType": "FunctionDefinition",
+              "parameters": {
+                "id": 8586,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8583,
+                    "name": "owner",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8590,
+                    "src": "1087:13:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8582,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1087:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8585,
+                    "name": "spender",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8590,
+                    "src": "1102:15:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8584,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1102:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "1086:32:62"
+              },
+              "returnParameters": {
+                "id": 8589,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8588,
+                    "name": "",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8590,
+                    "src": "1142:7:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8587,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1142:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "1141:9:62"
+              },
+              "scope": 8607,
+              "src": "1068:83:62",
+              "stateMutability": "view",
+              "superFunction": null,
+              "visibility": "external"
+            },
+            {
+              "anonymous": false,
+              "documentation": null,
+              "id": 8598,
+              "name": "Transfer",
+              "nodeType": "EventDefinition",
+              "parameters": {
+                "id": 8597,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8592,
+                    "indexed": true,
+                    "name": "from",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8598,
+                    "src": "1172:20:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8591,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1172:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8594,
+                    "indexed": true,
+                    "name": "to",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8598,
+                    "src": "1194:18:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8593,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1194:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8596,
+                    "indexed": false,
+                    "name": "value",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8598,
+                    "src": "1214:13:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8595,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1214:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "1171:57:62"
+              },
+              "src": "1157:72:62"
+            },
+            {
+              "anonymous": false,
+              "documentation": null,
+              "id": 8606,
+              "name": "Approval",
+              "nodeType": "EventDefinition",
+              "parameters": {
+                "id": 8605,
+                "nodeType": "ParameterList",
+                "parameters": [
+                  {
+                    "constant": false,
+                    "id": 8600,
+                    "indexed": true,
+                    "name": "owner",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8606,
+                    "src": "1250:21:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8599,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1250:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8602,
+                    "indexed": true,
+                    "name": "spender",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8606,
+                    "src": "1273:23:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName": {
+                      "id": 8601,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1273:7:62",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  {
+                    "constant": false,
+                    "id": 8604,
+                    "indexed": false,
+                    "name": "value",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 8606,
+                    "src": "1298:13:62",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName": {
+                      "id": 8603,
+                      "name": "uint256",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "1298:7:62",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "src": "1249:63:62"
+              },
+              "src": "1235:78:62"
+            }
+          ],
+          "scope": 8608,
+          "src": "302:1013:62"
+        }
+      ],
+      "src": "0:1316:62"
+    },
+    "compiler": {
+      "name": "solc",
+      "version": "0.5.16+commit.9c3226ce.Emscripten.clang"
+    },
+    "networks": {},
+    "schemaVersion": "3.0.19",
+    "updatedAt": "2020-02-25T19:49:36.294Z",
+    "devdoc": {
+      "details": "Interface for ERC20 with minting function Sourced from OpenZeppelin  (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC20/IERC20.sol)  and with an added permit() and mint() function. ",
+      "methods": {},
+      "title": "IERC20Permit"
+    },
+    "userdoc": {
+      "methods": {}
+    }
+  }

--- a/packages/contract-artifacts/src/index.js
+++ b/packages/contract-artifacts/src/index.js
@@ -3,6 +3,7 @@ const ACE = require('../artifacts/ACE');
 const AccountRegistryManager = require('../artifacts/AccountRegistryManager');
 const Behaviour20200106 = require('../artifacts/Behaviour20200106');
 const Behaviour20200207 = require('../artifacts/Behaviour20200207');
+const Behaviour20200220 = require('../artifacts/Behaviour20200220');
 const Dividend = require('../artifacts/Dividend');
 const DividendABIEncoder = require('../artifacts/DividendABIEncoder');
 const DividendInterface = require('../artifacts/DividendInterface');
@@ -50,6 +51,7 @@ module.exports = {
     AccountRegistryManager,
     Behaviour20200106,
     Behaviour20200207,
+    Behaviour20200220,
     Dividend,
     DividendABIEncoder,
     DividendInterface,

--- a/packages/dev-utils/src/constants.js
+++ b/packages/dev-utils/src/constants.js
@@ -137,6 +137,19 @@ constants.eip712 = {
         primaryType: 'JoinSplitSignature',
     },
     JOIN_SPLIT_SIGNATURE_TYPE_HASH,
+    PERMIT_SIGNATURE: {
+        types: {
+            PermitSignature: [
+                { name: 'holder', type: 'address' },
+                { name: 'spender', type: 'address' },
+                { name: 'nonce', type: 'uint256' },
+                { name: 'expiry', type: 'uint256' },
+                { name: 'allowed', type: 'bool' },
+            ],
+            EIP712Domain: EIP712_DOMAIN,
+        },
+        primaryType: 'PermitSignature',
+    },
     PROOF_SIGNATURE: {
         types: {
             ProofSignature: [

--- a/packages/dev-utils/src/constants.js
+++ b/packages/dev-utils/src/constants.js
@@ -80,6 +80,13 @@ const EIP712_DOMAIN = [
     { name: 'verifyingContract', type: 'address' },
 ];
 
+const EIP712_DOMAIN_CHAIN_ID = [
+    { name: 'name', type: 'string' },
+    { name: 'version', type: 'string' },
+    { name: 'chainId', type: 'uint256' },
+    { name: 'verifyingContract', type: 'address' },
+]
+
 // keccak256 hash of "EIP712Domain(string name,string version,address verifyingContract)"
 const EIP712_DOMAIN_SEPARATOR_SCHEMA_HASH = '0x91ab3d17e3a50a9d89e63fd30b92be7f5336b03b287bb946787a83a9d62a2766';
 
@@ -111,7 +118,12 @@ constants.eip712 = {
         version: '1',
         salt: '0x210db872dec2e06c375dd40a5a354307bb4ba52ba65bd84594554580ae6f0639',
     },
+    DAI_DOMAIN_PARAMS: {
+        name: 'Dai Stablecoin',
+        version: '1',
+    },
     EIP712_DOMAIN,
+    EIP712_DOMAIN_CHAIN_ID,
     EIP712_DOMAIN_SEPARATOR_SCHEMA_HASH,
     ACCOUNT_REGISTRY_SIGNATURE: {
         types: {
@@ -139,16 +151,16 @@ constants.eip712 = {
     JOIN_SPLIT_SIGNATURE_TYPE_HASH,
     PERMIT_SIGNATURE: {
         types: {
-            PermitSignature: [
+            Permit: [
                 { name: 'holder', type: 'address' },
                 { name: 'spender', type: 'address' },
                 { name: 'nonce', type: 'uint256' },
                 { name: 'expiry', type: 'uint256' },
                 { name: 'allowed', type: 'bool' },
             ],
-            EIP712Domain: EIP712_DOMAIN,
+            EIP712Domain: EIP712_DOMAIN_CHAIN_ID, // compatible with DAI contract
         },
-        primaryType: 'PermitSignature',
+        primaryType: 'Permit',
     },
     PROOF_SIGNATURE: {
         types: {

--- a/packages/dev-utils/src/constants.js
+++ b/packages/dev-utils/src/constants.js
@@ -85,7 +85,7 @@ const EIP712_DOMAIN_CHAIN_ID = [
     { name: 'version', type: 'string' },
     { name: 'chainId', type: 'uint256' },
     { name: 'verifyingContract', type: 'address' },
-]
+];
 
 // keccak256 hash of "EIP712Domain(string name,string version,address verifyingContract)"
 const EIP712_DOMAIN_SEPARATOR_SCHEMA_HASH = '0x91ab3d17e3a50a9d89e63fd30b92be7f5336b03b287bb946787a83a9d62a2766';

--- a/packages/extension/src/background/tasks/setupNetworkConfig.js
+++ b/packages/extension/src/background/tasks/setupNetworkConfig.js
@@ -10,6 +10,7 @@ const backgroundContracts = [
     'AccountRegistry',
     'ZkAsset',
     'ERC20',
+    'IERC20Permit',
 ];
 
 export default async function setupNetworkConfig({

--- a/packages/extension/src/client/services/MetaMaskService/index.js
+++ b/packages/extension/src/client/services/MetaMaskService/index.js
@@ -3,6 +3,7 @@ import * as ethUtil from 'ethereumjs-util';
 import Web3Service from '~/client/services/Web3Service';
 import registerExtension, { generateTypedData } from './registerExtension';
 import signNote from './signNote';
+import permitSchema from './permitSchema';
 import signProof from './signProof';
 
 const handleAction = async (action, params) => {
@@ -100,6 +101,37 @@ const handleAction = async (action, params) => {
             };
 
             break;
+        }
+            case 'metamask.eip712.permit': {
+                const {
+                    allowed,
+                    exipiry,
+                    nonce,
+                    spender,
+                    verifyingContract,
+                } = params;
+
+                const permitSchema = permit({
+                    allowed,
+                    exipiry,
+                    nonce,
+                    spender,
+                    verifyingContract
+                });
+                const method = 'eth_signTypedData_v4';
+                const { result } = await Web3Service.sendAsync({
+                    method,
+                    params: [address, permitSchema],
+                    from: address,
+                });
+
+                response = {
+                    signature: result,
+                };
+
+                break;
+            }
+            default:
         }
         default:
     }

--- a/packages/extension/src/client/services/MetaMaskService/index.js
+++ b/packages/extension/src/client/services/MetaMaskService/index.js
@@ -41,7 +41,6 @@ const handleAction = async (action, params) => {
             const sigParams = ethUtil.fromRpcSig(signature);
             const publicKey = ethUtil.ecrecover(hash, sigParams.v, sigParams.r, sigParams.s);
 
-
             response = {
                 signature: result,
                 publicKey,
@@ -102,38 +101,39 @@ const handleAction = async (action, params) => {
 
             break;
         }
-            case 'metamask.eip712.permit': {
-                const {
-                    allowed,
-                    exipiry,
-                    nonce,
-                    spender,
-                    verifyingContract,
-                } = params;
+        case 'metamask.eip712.permit': {
+            const {
+                allowed,
+                expiry,
+                nonce,
+                spender,
+                verifyingContract,
+            } = params;
 
-                const permitSchema = permit({
-                    allowed,
-                    exipiry,
-                    nonce,
-                    spender,
-                    verifyingContract
-                });
-                const method = 'eth_signTypedData_v4';
-                const { result } = await Web3Service.sendAsync({
-                    method,
-                    params: [address, permitSchema],
-                    from: address,
-                });
+            const permit = permitSchema({
+                allowed,
+                expiry,
+                nonce,
+                spender,
+                holder: address,
+                verifyingContract,
+                chainId: Web3Service.networkId,
+            });
+            const method = 'eth_signTypedData_v4';
+            const { result } = await Web3Service.sendAsync({
+                method,
+                params: [address, permit],
+                from: address,
+            });
 
-                response = {
-                    signature: result,
-                };
+            response = {
+                signature: result,
+            };
 
-                break;
-            }
-            default:
+            break;
         }
         default:
+            break;
     }
 
     return response;

--- a/packages/extension/src/client/services/MetaMaskService/permitSchema.js
+++ b/packages/extension/src/client/services/MetaMaskService/permitSchema.js
@@ -1,0 +1,36 @@
+import { signer } from 'aztec.js';
+import utils from '@aztec/dev-utils';
+
+const {
+    constants: {
+        eip712,
+    },
+} = utils;
+
+
+export default ({
+    spender,
+    verifyingContract,
+    allowed,
+    expiry,
+    spender,
+    nonce
+}) => {
+    const domain = signer.generateDAIDomainparams(chainId, verifyingContract);
+    const schema = eip712.PERMIT_SIGNATURE;
+
+    const message = {
+        allowed,
+        spender,
+        expiry,
+        nonce,
+    };
+
+    const data = JSON.stringify({
+        ...schema,
+        message,
+        domain,
+    });
+
+    return data;
+};

--- a/packages/extension/src/client/services/MetaMaskService/permitSchema.js
+++ b/packages/extension/src/client/services/MetaMaskService/permitSchema.js
@@ -7,21 +7,22 @@ const {
     },
 } = utils;
 
-
 export default ({
     spender,
     verifyingContract,
     allowed,
     expiry,
-    spender,
-    nonce
+    nonce,
+    chainId,
+    holder,
 }) => {
-    const domain = signer.generateDAIDomainparams(chainId, verifyingContract);
+    const domain = signer.generateDAIDomainParams(chainId, verifyingContract);
     const schema = eip712.PERMIT_SIGNATURE;
 
     const message = {
         allowed,
         spender,
+        holder,
         expiry,
         nonce,
     };

--- a/packages/extension/src/config/contracts/contracts.js
+++ b/packages/extension/src/config/contracts/contracts.js
@@ -27,4 +27,7 @@ export default {
     ERC20: {
         name: 'ERC20',
     },
+    IERC20Permit: {
+        name: 'IERC20Permit',
+    },
 };

--- a/packages/extension/src/config/contracts/development.js
+++ b/packages/extension/src/config/contracts/development.js
@@ -2,6 +2,7 @@ import AccountRegistry from '~contracts/IAccountRegistryBehaviour.json';
 import AccountRegistryManager from '~contracts/IAccountRegistryManager.json';
 import ACE from '~contracts/ACE.json';
 import IERC20 from '~contracts/IERC20Mintable.json';
+import IERC20Permit from '~contracts/IERC20Permit.json';
 import IZkAsset from '~contracts/IZkAsset.json';
 
 export default {
@@ -10,4 +11,5 @@ export default {
     ACE,
     ZkAsset: IZkAsset,
     ERC20: IERC20,
+    IERC20Permit,
 };

--- a/packages/extension/src/config/contracts/index.js
+++ b/packages/extension/src/config/contracts/index.js
@@ -20,6 +20,7 @@ const {
     ACE,
     ZkAsset,
     ERC20,
+    IERC20Permit,
 } = configs;
 
 export {
@@ -28,4 +29,5 @@ export {
     ACE,
     ZkAsset,
     ERC20,
+    IERC20Permit,
 };

--- a/packages/extension/src/config/contracts/production.js
+++ b/packages/extension/src/config/contracts/production.js
@@ -2,6 +2,7 @@ import AccountRegistry from '~contracts/IAccountRegistryBehaviour.json';
 import AccountRegistryManager from '~contracts/IAccountRegistryManager.json';
 import ACE from '~contracts/IACE.json';
 import IERC20 from '~contracts/IERC20Mintable.json';
+import IERC20Permit from '~contracts/IERC20Permit.json';
 import IZkAsset from '~contracts/IZkAsset.json';
 
 export default {
@@ -10,4 +11,5 @@ export default {
     ACE,
     ZkAsset: IZkAsset,
     ERC20: IERC20,
+    IERC20Permit,
 };

--- a/packages/extension/src/config/supportsPermitSignature.js
+++ b/packages/extension/src/config/supportsPermitSignature.js
@@ -1,3 +1,3 @@
 export default {
-    '0x6b175474e89094c44da98b954eedeac495271d0f': true,
+    '0x6B175474E89094C44Da98b954EedeAC495271d0F': true,
 };

--- a/packages/extension/src/config/supportsPermitSignature.js
+++ b/packages/extension/src/config/supportsPermitSignature.js
@@ -1,0 +1,3 @@
+export default {
+    '0x6b175474e89094c44da98b954eedeac495271d0f': true,
+};

--- a/packages/extension/src/ui/apis/asset/depositWithPermit.js
+++ b/packages/extension/src/ui/apis/asset/depositWithPermit.js
@@ -26,6 +26,7 @@ export default async function deposit({
             erc20Amount.toString(),
             signature,
             nonce,
+            expiry,
         ],
     };
 

--- a/packages/extension/src/ui/apis/asset/depositWithPermit.js
+++ b/packages/extension/src/ui/apis/asset/depositWithPermit.js
@@ -26,7 +26,6 @@ export default async function deposit({
             erc20Amount.toString(),
             signature,
             nonce,
-            expiry,
         ],
     };
 

--- a/packages/extension/src/ui/apis/asset/depositWithPermit.js
+++ b/packages/extension/src/ui/apis/asset/depositWithPermit.js
@@ -1,0 +1,44 @@
+import ConnectionService from '~/ui/services/ConnectionService';
+
+export default async function deposit({
+    currentAccount: {
+        address: currentAddress,
+    },
+    erc20Amount,
+    assetAddress,
+    proof,
+    isGSNAvailable,
+    signature,
+    expiry,
+    nonce,
+}) {
+    const proofHash = proof.hash;
+    const proofData = proof.encodeABI(assetAddress);
+
+    const transactionData = {
+        contract: 'AccountRegistry',
+        method: 'deposit',
+        data: [
+            assetAddress,
+            currentAddress,
+            proofHash,
+            proofData,
+            erc20Amount.toString(),
+            signature,
+            nonce,
+            expiry,
+        ],
+    };
+
+    const response = isGSNAvailable
+        ? await ConnectionService.sendTransaction(transactionData)
+        : await ConnectionService.post({
+            action: 'metamask.send',
+            data: transactionData,
+        });
+
+    return {
+        ...response,
+        success: !!(response && response.txReceipt),
+    };
+}

--- a/packages/extension/src/ui/apis/asset/index.js
+++ b/packages/extension/src/ui/apis/asset/index.js
@@ -23,5 +23,5 @@ export {
     confidentialTransfer,
     updateNoteMetadata,
     deposit,
-    depositWithPermit
+    depositWithPermit,
 };

--- a/packages/extension/src/ui/apis/asset/index.js
+++ b/packages/extension/src/ui/apis/asset/index.js
@@ -3,10 +3,12 @@ import getAssets from './getAssets';
 import getDomainAssets from './getDomainAssets';
 import getLinkedTokenAddress from './getLinkedTokenAddress';
 import approveERC20Allowance from './approveERC20Allowance';
+import permitERC20Allowance from './permitERC20Allowance';
 import confidentialTransferFrom from './confidentialTransferFrom';
 import confidentialTransfer from './confidentialTransfer';
 import updateNoteMetadata from './updateNoteMetadata';
 import deposit from './deposit';
+import depositWithPermit from './depositWithPermit';
 
 export const getPastTransactions = () => [];
 
@@ -16,8 +18,10 @@ export {
     getDomainAssets,
     getLinkedTokenAddress,
     approveERC20Allowance,
+    permitERC20Allowance,
     confidentialTransferFrom,
     confidentialTransfer,
     updateNoteMetadata,
     deposit,
+    depositWithPermit
 };

--- a/packages/extension/src/ui/apis/asset/permitERC20Allowance.js
+++ b/packages/extension/src/ui/apis/asset/permitERC20Allowance.js
@@ -20,7 +20,6 @@ export default async function permitERC20({
                 allowanceSpender,
             );
     } catch (e) {
-        console.log(e);
         error = e;
     }
     const expiry = Date.now() + 24 * 60 * 60;

--- a/packages/extension/src/ui/apis/asset/permitERC20Allowance.js
+++ b/packages/extension/src/ui/apis/asset/permitERC20Allowance.js
@@ -1,0 +1,54 @@
+import ConnectionService from '~/ui/services/ConnectionService';
+import Web3Service from '~/helpers/Web3Service';
+
+export default async function permitERC20({
+    asset,
+    requestedAllowance,
+    allowanceSpender,
+}) {
+
+
+    const {
+        linkedTokenAddress,
+    } = asset;
+
+    let error;
+    try {
+       const nonce =  await Web3Service
+            .useContract('ERC20')
+            .at(linkedTokenAddress)
+            .method('nonces')
+            .send(
+                allowanceSpender,
+            );
+    } catch (e) {
+        error = e;
+    }
+    const exipry = Date.now() + 24 * 60 * 60;
+    const {
+        signature,
+        error,
+    } = await ConnectionService.post({
+        action: 'metamask.eip712.permit',
+        data: {
+            nonce,
+            expiry,
+            allowed: requestedAllowance
+            spender: allowanceSpender,
+        },
+    });
+
+    if (error) {
+        return {
+            error,
+        };
+    }
+
+    return {
+        spender: sender,
+        nonce,
+        expiry,
+        allowed; requestedAllowance,
+        signature,
+    };
+}

--- a/packages/extension/src/ui/apis/asset/permitERC20Allowance.js
+++ b/packages/extension/src/ui/apis/asset/permitERC20Allowance.js
@@ -3,52 +3,52 @@ import Web3Service from '~/helpers/Web3Service';
 
 export default async function permitERC20({
     asset,
-    requestedAllowance,
     allowanceSpender,
 }) {
-
-
     const {
         linkedTokenAddress,
     } = asset;
 
     let error;
+    let nonce;
     try {
-       const nonce =  await Web3Service
-            .useContract('ERC20')
+        nonce = await Web3Service
+            .useContract('IERC20Permit')
             .at(linkedTokenAddress)
             .method('nonces')
-            .send(
+            .call(
                 allowanceSpender,
             );
     } catch (e) {
+        console.log(e);
         error = e;
     }
-    const exipry = Date.now() + 24 * 60 * 60;
+    const expiry = Date.now() + 24 * 60 * 60;
     const {
         signature,
-        error,
+        error: errorSig,
     } = await ConnectionService.post({
         action: 'metamask.eip712.permit',
         data: {
             nonce,
             expiry,
-            allowed: requestedAllowance
+            allowed: true,
+            verifyingContract: linkedTokenAddress,
             spender: allowanceSpender,
         },
     });
 
-    if (error) {
+    if (errorSig || error) {
         return {
-            error,
+            error: errorSig || error,
         };
     }
 
     return {
-        spender: sender,
+        spender: allowanceSpender,
         nonce,
         expiry,
-        allowed; requestedAllowance,
+        allowed: true,
         signature,
     };
 }

--- a/packages/extension/src/ui/pages/Deposit.jsx
+++ b/packages/extension/src/ui/pages/Deposit.jsx
@@ -53,6 +53,11 @@ const Deposit = ({
             steps = depositSteps.gsnTransfer;
         }
 
+        const tokenSupportsPermit = getTokenPermitStatus(asset.linkedTokenAddress);
+        if (tokenSupportsPermit) {
+            steps = depositSteps.gsnWithPermit;
+        }
+
         const allowance = await Web3Service
             .useContract('ERC20')
             .at(asset.linkedTokenAddress)
@@ -65,7 +70,7 @@ const Deposit = ({
         const erc20Amount = asset.scalingFactor.mul(new BN(amount));
         const requestedAllowance = erc20Amount;
         if (approvedERC20Allowance.gte(requestedAllowance)) {
-            steps = steps.filter(({ name }) => name !== 'approveERC20');
+            steps = steps.filter(({ name }) => name !== 'approveERC20' || 'permitERC20');
         }
 
         return {

--- a/packages/extension/src/ui/pages/Deposit.jsx
+++ b/packages/extension/src/ui/pages/Deposit.jsx
@@ -53,7 +53,7 @@ const Deposit = ({
             steps = depositSteps.gsnTransfer;
         }
 
-        const tokenSupportsPermit = getTokenPermitStatus(asset.linkedTokenAddress);
+        const tokenSupportsPermit = asset.supportsPermit;
         if (tokenSupportsPermit) {
             steps = depositSteps.gsnWithPermit;
         }

--- a/packages/extension/src/ui/steps/deposit.js
+++ b/packages/extension/src/ui/steps/deposit.js
@@ -124,6 +124,32 @@ const stepSendViaGSN = {
     submitTextKey: 'transaction.send.submit',
 };
 
+const stepSendViaGSNPermit = {
+    name: 'send',
+    descriptionKey: 'transaction.gsn.send.description',
+    blockStyle: 'sealed',
+    tasks: [
+        {
+            titleKey: 'transaction.step.create.proof',
+            run: apis.mock,
+        },
+        {
+            titleKey: 'transaction.step.sign',
+            run: apis.mock,
+        },
+        {
+            titleKey: 'transaction.step.relay',
+            run: apis.asset.depositWithPermit,
+        },
+        {
+            titleKey: 'transaction.confirmed',
+        },
+    ],
+    showTaskList: true,
+    autoStart: true,
+    submitTextKey: 'transaction.send.submit',
+};
+
 export default {
     gsn: [
         stepApproveERC20,
@@ -138,7 +164,7 @@ export default {
     gsnWithPermit: [
         stepPermitERC20,
         stepConfirmForGSN,
-        stepSendViaGSN,
+        stepSendViaGSNPermit,
     ],
 
     metamask: [

--- a/packages/extension/src/ui/steps/deposit.js
+++ b/packages/extension/src/ui/steps/deposit.js
@@ -13,6 +13,20 @@ const stepApproveERC20 = {
     submitTextKey: 'transaction.approve.submit',
 };
 
+
+const stepPermitERC20 = {
+    name: 'permitERC20',
+    descriptionKey: 'deposit.approve.description',
+    blockStyle: 'linked',
+    tasks: [
+        {
+            type: 'sign',
+            run: apis.asset.permitERC20Allowance,
+        },
+    ],
+    submitTextKey: 'transaction.approve.submit',
+};
+
 const stepConfirm = {
     name: 'confirmTransaction',
     descriptionKey: 'deposit.send.description',
@@ -121,6 +135,12 @@ export default {
         stepConfirmForGSN,
         stepTransferViaGSN,
     ],
+    gsnWithPermit: [
+        stepPermitERC20,
+        stepConfirmForGSN,
+        stepSendViaGSN,
+    ],
+
     metamask: [
         stepApproveERC20,
         stepConfirm,

--- a/packages/extension/src/ui/utils/makeAsset.js
+++ b/packages/extension/src/ui/utils/makeAsset.js
@@ -29,12 +29,14 @@ export default async function makeAsset(asset) {
         icon,
         symbol,
         decimals,
+        supportsPermit,
     } = linkedTokenAddress
         ? makeToken(linkedTokenAddress)
         : {};
 
     return {
         ...assetObj,
+        supportsPermit,
         name,
         icon,
         symbol,

--- a/packages/extension/src/ui/utils/makeToken.js
+++ b/packages/extension/src/ui/utils/makeToken.js
@@ -3,6 +3,8 @@ import {
     getResourceUrl,
 } from '~/utils/versionControl';
 
+import supportsPermit from '~/config/supportsPermitSignature';
+
 const publicResourcePath = getResourceUrl('public');
 
 const formatIconUrl = (icon) => {
@@ -24,5 +26,6 @@ export default function makeToken(address) {
         symbol,
         decimals,
         icon: formatIconUrl(logo),
+        supportsPermit: supportsPermit[address],
     };
 }

--- a/packages/extension/src/ui/views/DepositContent.jsx
+++ b/packages/extension/src/ui/views/DepositContent.jsx
@@ -34,8 +34,8 @@ class DepositContent extends StepContentHelper {
         } = this.props;
 
         const currentStepName = steps[currentStep].name;
-        const approved = steps.every(({ name }) => name !== 'approveERC20')
-            || isStepAfter(steps, currentStepName, 'approveERC20');
+        const approved = steps.every(({ name }) => name !== 'approveERC20' && name !== 'permitERC20')
+            || isStepAfter(steps, currentStepName, 'approveERC20') || isStepAfter(steps, currentStepName, 'permitERC20');
 
         const {
             name: assetName,

--- a/packages/extension/src/utils/Web3Service.js
+++ b/packages/extension/src/utils/Web3Service.js
@@ -374,7 +374,7 @@ class Web3Service {
                                 try {
                                     gasPrice = await web3.eth.getGasPrice();
                                 } catch (e) {
-                                    console.log(e);
+                                    errorLog(e);
                                 }
                                 return this.triggerMethod('send', {
                                     method: gsnContract.methods[methodName],

--- a/packages/integration-test/src/setup.js
+++ b/packages/integration-test/src/setup.js
@@ -109,8 +109,9 @@ class Setup {
      * @param {string} address - (optional) address at which the contract should be instantiated. Can be supplied to override the
      * default address used, whereby the default is the address associated with the `nameOfContract`.
      *
-     * An example of where `address` will be supplied is when generating a deployed proxy contract. In this case the address will be
-     * the address of the proxy, whilst `nameOfContract` will be the behaviour implementation the address is cast with.
+     * An example of where `address` will be supplied is when generating a deployed
+     * proxy contract. In this case the address will be the address of the proxy, whilst
+     * `nameOfContract` will be the behaviour implementation the address is cast with.
      */
     getContractPromise(nameOfContract, address = null) {
         const extractedContractArtifact = contractArtifacts[nameOfContract];

--- a/packages/monorepo-scripts/addresses/update.js
+++ b/packages/monorepo-scripts/addresses/update.js
@@ -16,6 +16,7 @@ const deployedContracts = [
     'AccountRegistryManager',
     'Behaviour20200106',
     'Behaviour20200207',
+    'Behaviour20200220',
     'Dividend',
     'ERC20Mintable',
     'FactoryAdjustable201907',

--- a/packages/protocol/contracts/AccountRegistry/epochs/20200220/Behaviour20200220.sol
+++ b/packages/protocol/contracts/AccountRegistry/epochs/20200220/Behaviour20200220.sol
@@ -1,0 +1,131 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "../20200207/Behaviour20200207.sol";
+import "../../../interfaces/IERC20Permit.sol";
+
+/**
+ * @title Behaviour20200220 implementation
+ * @author AZTEC
+ * @dev This behaviour contract overloads the deposit() account registry method, with a deposit() 
+ * implementation that is compatible with the DAI permit() function.
+ * 
+ * Note the behaviour contract version naming convention is based on the date on which the contract
+ * was created, in the format: YYYYMMDD
+ * 
+ * Copyright 2020 Spilsbury Holdings Ltd 
+ *
+ * Licensed under the GNU Lesser General Public Licence, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **/
+contract Behaviour20200220 is Behaviour20200207 {
+    /**
+    * @dev epoch number, used for version control in upgradeability. The naming convention is based on the
+    * date on which the contract was created, in the format: YYYYMMDD
+    */
+    uint256 public epoch = 20200220;
+
+    event ContractAddress(address variable);
+
+    /**
+    * @dev This deposit() implementation performs the standard AccountRegistry deposit functionality, but it
+    * is also specifically compatible with the DAI permit() function. 
+    
+    * The permit() function removes the need for a user to send a seperate approval() transaction
+    * beforehand in order to approve another address to spend DAI on their behalf. 
+    * 
+    * @param _registryOwner - owner of the zkAsset
+    * @param _owner - owner of the ERC20s being deposited
+    * @param _proofHash - hash of the zero-knowledge deposit proof
+    * @param _proofData - cryptographic data associated with the zero-knowledge proof
+    * @param _value - number of ERC20s being deposited
+     */
+    function deposit(
+        address _registryOwner,
+        address _owner,
+        bytes32 _proofHash,
+        bytes memory _proofData,
+        uint256 _value,
+        bytes memory signature,
+        uint256 nonce     
+    ) public {
+        emit ContractAddress(address(this));
+        bytes memory proofOutputs = ace.validateProof(
+            JOIN_SPLIT_PROOF,
+            address(this),
+            _proofData
+        );
+
+
+        if (_owner != _msgSender()) {
+            require(
+                userToAZTECAccountMapping[_owner] == _msgSender(),
+                "Sender has no permission to deposit on owner's behalf."
+            );
+
+            (,
+            bytes memory proofOutputNotes,
+            ,
+            ) = proofOutputs.get(0).extractProofOutput();
+            uint256 numberOfNotes = proofOutputNotes.getLength();
+            for (uint256 i = 0; i < numberOfNotes; i += 1) {
+                (address owner,,) = proofOutputNotes.get(i).extractNote();
+                require(owner == _owner, "Cannot deposit note to other account if sender is not the same as owner.");
+            }
+        }
+
+        (address linkedTokenAddress,,,,,,,) = ace.getRegistry(_registryOwner);
+        IERC20Permit linkedToken = IERC20Permit(linkedTokenAddress);
+
+        permit(linkedTokenAddress, _owner, nonce, signature);
+
+        linkedToken.transferFrom(
+            _owner,
+            address(this),
+            _value
+        );
+
+        linkedToken.approve(address(ace), _value);
+
+        ace.publicApprove(_registryOwner, _proofHash, _value);
+
+        IZkAsset(_registryOwner).confidentialTransferFrom(
+            JOIN_SPLIT_PROOF,
+            proofOutputs.get(0)
+        );
+    }
+
+    /**
+    * @dev Call linkedToken.permit(), to grant an address approval to spend linkedToken tokens
+    * on holder's behalf. Makes use of the new DAI permit() method
+    *
+    * @param linkedTokenAddress - address of the linkedToken
+    * @param holder - owner of the ERC20 tokens, which are being approved to be spent by the spender
+    * @param signature - signature required for permit function
+    */
+    function permit(address linkedTokenAddress, address holder, uint256 nonce, bytes memory signature) public {
+        bool allowed = true;
+        uint256 expiry = uint256(-1);
+        address spender = address(this);
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+
+        assembly {
+            r := mload(add(signature, 0x20))
+            s := mload(add(signature, 0x40))
+            v := mload(add(signature, 0x41))
+        }
+
+        IERC20Permit(linkedTokenAddress).permit(holder, spender, nonce, expiry, allowed, v, r, s);
+    }
+}
+

--- a/packages/protocol/contracts/AccountRegistry/epochs/20200220/Behaviour20200220.sol
+++ b/packages/protocol/contracts/AccountRegistry/epochs/20200220/Behaviour20200220.sol
@@ -46,6 +46,7 @@ contract Behaviour20200220 is Behaviour20200207 {
     * @param _value - number of ERC20s being deposited
     * @param signature - EIP712 signature supplied to permit() for granting approval
     * @param nonce - permit nonce used for signature replay protection
+    * @param expiry - unix timestamp up to which the permit is valid
      */
     function deposit(
         address _registryOwner,

--- a/packages/protocol/contracts/AccountRegistry/interfaces/IAccountRegistryBehaviour.sol
+++ b/packages/protocol/contracts/AccountRegistry/interfaces/IAccountRegistryBehaviour.sol
@@ -62,6 +62,16 @@ contract IAccountRegistryBehaviour {
         bytes calldata _proofData,
         uint256 _value
     ) external;
+    
+    function deposit(
+        address _registryOwner,
+        address _owner,
+        bytes32 _proofHash,
+        bytes memory _proofData,
+        uint256 _value,
+        bytes memory signature,
+        uint256 nonce
+    ) external;
 
     function publicApprove(address _registryOwner, bytes32 _proofHash, uint256 _value) external;
 

--- a/packages/protocol/contracts/AccountRegistry/interfaces/IAccountRegistryBehaviour.sol
+++ b/packages/protocol/contracts/AccountRegistry/interfaces/IAccountRegistryBehaviour.sol
@@ -67,9 +67,9 @@ contract IAccountRegistryBehaviour {
         address _registryOwner,
         address _owner,
         bytes32 _proofHash,
-        bytes memory _proofData,
+        bytes calldata _proofData,
         uint256 _value,
-        bytes memory signature,
+        bytes calldata signature,
         uint256 nonce
     ) external;
 

--- a/packages/protocol/contracts/AccountRegistry/interfaces/IAccountRegistryBehaviour.sol
+++ b/packages/protocol/contracts/AccountRegistry/interfaces/IAccountRegistryBehaviour.sol
@@ -70,7 +70,18 @@ contract IAccountRegistryBehaviour {
         bytes calldata _proofData,
         uint256 _value,
         bytes calldata signature,
-        uint256 nonce
+        uint256 nonce,
+        uint256 expiry
+    ) external;
+
+    function permit(
+        address linkedTokenAddress,
+        address holder,
+        uint256 nonce,
+        bool allowed,
+        uint256 expiry,
+        address spender,
+        bytes calldata signature
     ) external;
 
     function publicApprove(address _registryOwner, bytes32 _proofHash, uint256 _value) external;

--- a/packages/protocol/contracts/interfaces/IERC20Permit.sol
+++ b/packages/protocol/contracts/interfaces/IERC20Permit.sol
@@ -1,0 +1,41 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+
+/**
+ * @title IERC20Permit
+ * @dev Interface for ERC20 with minting function
+ * Sourced from OpenZeppelin 
+ * (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC20/IERC20.sol) 
+ * and with an added permit() and mint() function. 
+ */
+interface IERC20Permit {
+
+    function transfer(address to, uint256 value) external returns (bool);
+
+    function approve(address spender, uint256 value) external returns (bool);
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+    
+    function permit(
+        address holder,
+        address spender,
+        uint256 nonce,
+        uint256 expiry,
+        bool allowed,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;   
+
+    function mint(address _to, uint256 _value) external returns (bool);   
+
+    function totalSupply() external view returns (uint256);
+
+    function balanceOf(address who) external view returns (uint256);
+
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/packages/protocol/contracts/interfaces/IERC20Permit.sol
+++ b/packages/protocol/contracts/interfaces/IERC20Permit.sol
@@ -8,8 +8,9 @@ pragma solidity >=0.5.0 <0.6.0;
  * (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC20/IERC20.sol) 
  * and with an added permit() and mint() function. 
  */
-interface IERC20Permit {
+contract IERC20Permit {
 
+    mapping (address => uint)                      public nonces;
     function transfer(address to, uint256 value) external returns (bool);
 
     function approve(address spender, uint256 value) external returns (bool);

--- a/packages/protocol/contracts/test/ERC20/DAI/dai.sol
+++ b/packages/protocol/contracts/test/ERC20/DAI/dai.sol
@@ -1,0 +1,141 @@
+// Copyright (C) 2017, 2018, 2019 dbrock, rain, mrchico
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.5.12;
+
+import "./lib.sol";
+
+contract Dai is LibNote {
+    // --- Auth ---
+    mapping (address => uint) public wards;
+    function rely(address guy) external note auth { wards[guy] = 1; }
+    function deny(address guy) external note auth { wards[guy] = 0; }
+    modifier auth {
+        require(wards[msg.sender] == 1, "Dai/not-authorized");
+        _;
+    }
+
+    // --- ERC20 Data ---
+    string  public constant name     = "Dai Stablecoin";
+    string  public constant symbol   = "DAI";
+    string  public constant version  = "1";
+    uint8   public constant decimals = 18;
+    uint256 public totalSupply;
+
+    mapping (address => uint)                      public balanceOf;
+    mapping (address => mapping (address => uint)) public allowance;
+    mapping (address => uint)                      public nonces;
+
+    event Approval(address indexed src, address indexed guy, uint wad);
+    event Transfer(address indexed src, address indexed dst, uint wad);
+
+    // --- Math ---
+    function add(uint x, uint y) internal pure returns (uint z) {
+        require((z = x + y) >= x);
+    }
+    function sub(uint x, uint y) internal pure returns (uint z) {
+        require((z = x - y) <= x);
+    }
+
+    // --- EIP712 niceties ---
+    bytes32 public DOMAIN_SEPARATOR;
+    // bytes32 public constant PERMIT_TYPEHASH = keccak256("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)");
+    bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
+
+    constructor(uint256 chainId_) public {
+        wards[msg.sender] = 1;
+        DOMAIN_SEPARATOR = keccak256(abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256(bytes(name)),
+            keccak256(bytes(version)),
+            chainId_,
+            address(this)
+        ));
+    }
+
+    // --- Token ---
+    function transfer(address dst, uint wad) external returns (bool) {
+        return transferFrom(msg.sender, dst, wad);
+    }
+    function transferFrom(address src, address dst, uint wad)
+        public returns (bool)
+    {
+        require(balanceOf[src] >= wad, "Dai/insufficient-balance");
+        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+            require(allowance[src][msg.sender] >= wad, "Dai/insufficient-allowance");
+            allowance[src][msg.sender] = sub(allowance[src][msg.sender], wad);
+        }
+        balanceOf[src] = sub(balanceOf[src], wad);
+        balanceOf[dst] = add(balanceOf[dst], wad);
+        emit Transfer(src, dst, wad);
+        return true;
+    }
+    function mint(address usr, uint wad) external auth {
+        balanceOf[usr] = add(balanceOf[usr], wad);
+        totalSupply    = add(totalSupply, wad);
+        emit Transfer(address(0), usr, wad);
+    }
+    function burn(address usr, uint wad) external {
+        require(balanceOf[usr] >= wad, "Dai/insufficient-balance");
+        if (usr != msg.sender && allowance[usr][msg.sender] != uint(-1)) {
+            require(allowance[usr][msg.sender] >= wad, "Dai/insufficient-allowance");
+            allowance[usr][msg.sender] = sub(allowance[usr][msg.sender], wad);
+        }
+        balanceOf[usr] = sub(balanceOf[usr], wad);
+        totalSupply    = sub(totalSupply, wad);
+        emit Transfer(usr, address(0), wad);
+    }
+    function approve(address usr, uint wad) external returns (bool) {
+        allowance[msg.sender][usr] = wad;
+        emit Approval(msg.sender, usr, wad);
+        return true;
+    }
+
+    // --- Alias ---
+    function push(address usr, uint wad) external {
+        transferFrom(msg.sender, usr, wad);
+    }
+    function pull(address usr, uint wad) external {
+        transferFrom(usr, msg.sender, wad);
+    }
+    function move(address src, address dst, uint wad) external {
+        transferFrom(src, dst, wad);
+    }
+
+    // --- Approve by signature ---
+    function permit(address holder, address spender, uint256 nonce, uint256 expiry,
+                    bool allowed, uint8 v, bytes32 r, bytes32 s) external
+    {
+        bytes32 digest =
+            keccak256(abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                keccak256(abi.encode(PERMIT_TYPEHASH,
+                                     holder,
+                                     spender,
+                                     nonce,
+                                     expiry,
+                                     allowed))
+        ));
+
+        require(holder != address(0), "Dai/invalid-address-0");
+        require(holder == ecrecover(digest, v, r, s), "Dai/invalid-permit");
+        require(expiry == 0 || now <= expiry, "Dai/permit-expired");
+        require(nonce == nonces[holder]++, "Dai/invalid-nonce");
+        uint wad = allowed ? uint(-1) : 0;
+        allowance[holder][spender] = wad;
+        emit Approval(holder, spender, wad);
+    }
+}

--- a/packages/protocol/contracts/test/ERC20/DAI/dai.sol
+++ b/packages/protocol/contracts/test/ERC20/DAI/dai.sol
@@ -51,7 +51,8 @@ contract Dai is LibNote {
 
     // --- EIP712 niceties ---
     bytes32 public DOMAIN_SEPARATOR;
-    // bytes32 public constant PERMIT_TYPEHASH = keccak256("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)");
+    // bytes32 public constant PERMIT_TYPEHASH = 
+    // keccak256("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)");
     bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
 
     constructor(uint256 chainId_) public {
@@ -123,11 +124,11 @@ contract Dai is LibNote {
                 "\x19\x01",
                 DOMAIN_SEPARATOR,
                 keccak256(abi.encode(PERMIT_TYPEHASH,
-                                     holder,
-                                     spender,
-                                     nonce,
-                                     expiry,
-                                     allowed))
+                                    holder,
+                                    spender,
+                                    nonce,
+                                    expiry,
+                                    allowed))
         ));
 
         require(holder != address(0), "Dai/invalid-address-0");

--- a/packages/protocol/contracts/test/ERC20/DAI/lib.sol
+++ b/packages/protocol/contracts/test/ERC20/DAI/lib.sol
@@ -1,0 +1,43 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.5.12;
+
+contract LibNote {
+    event LogNote(
+        bytes4   indexed  sig,
+        address  indexed  usr,
+        bytes32  indexed  arg1,
+        bytes32  indexed  arg2,
+        bytes             data
+    ) anonymous;
+
+    modifier note {
+        _;
+        assembly {
+            // log an 'anonymous' event with a constant 6 words of calldata
+            // and four indexed topics: selector, caller, arg1 and arg2
+            let mark := msize                         // end of memory ensures zero
+            mstore(0x40, add(mark, 288))              // update free memory pointer
+            mstore(mark, 0x20)                        // bytes type data offset
+            mstore(add(mark, 0x20), 224)              // bytes size (padded)
+            calldatacopy(add(mark, 0x40), 0, 224)     // bytes payload
+            log4(mark, 288,                           // calldata
+                 shl(224, shr(224, calldataload(0))), // msg.sig
+                 caller,                              // msg.sender
+                 calldataload(4),                     // arg1
+                 calldataload(36)                     // arg2
+                )
+        }
+    }
+}

--- a/packages/protocol/contracts/test/ERC20/DAI/lib.sol
+++ b/packages/protocol/contracts/test/ERC20/DAI/lib.sol
@@ -33,10 +33,10 @@ contract LibNote {
             mstore(add(mark, 0x20), 224)              // bytes size (padded)
             calldatacopy(add(mark, 0x40), 0, 224)     // bytes payload
             log4(mark, 288,                           // calldata
-                 shl(224, shr(224, calldataload(0))), // msg.sig
-                 caller,                              // msg.sender
-                 calldataload(4),                     // arg1
-                 calldataload(36)                     // arg2
+                shl(224, shr(224, calldataload(0))), // msg.sig
+                caller,                              // msg.sender
+                calldataload(4),                     // arg1
+                calldataload(36)                     // arg2
                 )
         }
     }

--- a/packages/protocol/migrations/17_deploy_accountRegistryBehaviour20200220.js
+++ b/packages/protocol/migrations/17_deploy_accountRegistryBehaviour20200220.js
@@ -1,0 +1,33 @@
+/* global artifacts */
+const dotenv = require('dotenv');
+const { getContractAddressesForNetwork, NetworkId: networkIds } = require('@aztec/contract-addresses');
+
+dotenv.config();
+const AccountRegistryBehaviour20200220 = artifacts.require('./AccountRegistry/epochs/20200207/Behaviour20200220');
+const AccountRegistryManager = artifacts.require('./AccountRegistry/AccountRegistryManager');
+
+module.exports = (deployer, network) => {
+    return deployer.deploy(AccountRegistryBehaviour20200220).then(async (behaviourContract) => {
+        const isLocal = network === 'development' || network === 'test';
+
+        // Get the manager contract instance
+        let managerContract;
+        if (isLocal) {
+            managerContract = await AccountRegistryManager.deployed();
+        } else {
+            const formattedNetwork = network[0].toUpperCase() + network.slice(1);
+            const { AccountRegistryManager: managerAddress } = getContractAddressesForNetwork(networkIds[formattedNetwork]);
+            managerContract = await AccountRegistryManager.at(managerAddress);
+        }
+
+        // Perform the upgrade
+        await managerContract.upgradeAccountRegistry(behaviourContract.address);
+
+        // Get the proxy contract instance
+        const proxyAddress = await managerContract.proxyAddress();
+        const proxyContract = await AccountRegistryBehaviour20200220.at(proxyAddress);
+
+        // Set the GSN signer address
+        await proxyContract.setGSNSigner();
+    });
+};

--- a/packages/protocol/test/AccountRegistry/epochs/20200220/Behaviour20200220.js
+++ b/packages/protocol/test/AccountRegistry/epochs/20200220/Behaviour20200220.js
@@ -1,0 +1,186 @@
+/* globals contract, artifacts, expect */
+const {
+    JoinSplitProof,
+    note,
+    signer: { signPermit },
+} = require('aztec.js');
+const { generateAccount } = require('@aztec/secp256k1');
+const BN = require('bn.js');
+const truffleAssert = require('truffle-assertions');
+const { randomHex } = require('web3-utils');
+
+const ACE = artifacts.require('./ACE');
+const AccountRegistryManager = artifacts.require('./AccountRegistry/AccountRegistryManager');
+const Behaviour20200106 = artifacts.require('./Behaviour20200106/epochs/20200106/Behaviour20200106');
+const Behaviour20200220 = artifacts.require('./Behaviour20200106/epochs/20200106/Behaviour20200220');
+const DAI = artifacts.require('./test/ERC20/DAI/dai');
+const ZkAsset = artifacts.require('ZkAssetOwnable');
+
+const standardAccount = require('../../../helpers/getOwnerAccount');
+
+contract('Behaviour20200220', async (accounts) => {
+    let behaviour20200220;
+    let manager;
+    let proxyContract;
+    let dai;
+    let ace;
+    let zkAsset;
+
+    const opts = { from: accounts[0] };
+    const updatedGSNSignerAddress = '0x5323B6bbD3421983323b3f4f0B11c2D6D3bCE1d8';
+
+    // Signature params
+    const chainID = 4;
+    const nonce = 1;
+    const expiry = -1; // a massive number in the contract
+    const allowed = true;
+
+    beforeEach(async () => {
+        ace = await ACE.deployed();
+
+        // deploy DAI contract
+        dai = await DAI.new(chainID, opts);
+
+        zkAsset = await ZkAsset.new(ace.address, dai.address, 1, {
+            from: accounts[2],
+        });
+
+        const behaviour20200106 = await Behaviour20200106.new();
+        const initialBehaviourAddress = behaviour20200106.address;
+        const initialGSNSignerAddress = randomHex(20);
+        manager = await AccountRegistryManager.new(initialBehaviourAddress, ace.address, initialGSNSignerAddress, opts);
+
+        // perform behaviour upgrade
+        behaviour20200220 = await Behaviour20200220.new();
+        await manager.upgradeAccountRegistry(behaviour20200220.address);
+        const proxyAddress = await manager.proxyAddress();
+        proxyContract = await Behaviour20200220.at(proxyAddress);
+
+        // set the GSN signer
+        await proxyContract.setGSNSigner();
+    });
+
+    describe('Initialisation', async () => {
+        it('should have set the GSN signer address', async () => {
+            const updatedGSNSigner = await proxyContract.GSNSigner();
+            expect(updatedGSNSigner.toString()).to.equal(updatedGSNSignerAddress);
+        });
+
+        it('should deploy DAI contract', async () => {
+            expect(dai.address).to.not.equal(undefined);
+        });
+    });
+
+    describe('Success states', async () => {
+        it('should update allowance using direct DAI.permit() call', async () => {
+            const holderAccount = generateAccount();
+            const { address: holderAddress } = holderAccount;
+            const spender = randomHex(20);
+            const verifyingContract = dai.address;
+
+            const permitSig = signPermit(chainID, verifyingContract, holderAccount, spender, nonce, expiry, allowed).slice(2);
+
+            const r = `0x${permitSig.slice(0, 64)}`;
+            const s = `0x${permitSig.slice(64, 128)}`;
+            const v = `0x${permitSig.slice(128, 130)}`;
+
+            const { receipt } = await dai.permit(holderAddress, spender, nonce, expiry, allowed, v, r, s);
+            expect(receipt.status).to.equal(true);
+
+            const allowance = await dai.allowance.call(holderAddress, spender);
+            expect(allowance.toString()).to.not.equal('0');
+        });
+
+        it('should update allowance using indirect proxyContract.permit() call', async () => {
+            const linkedTokenAddress = dai.address;
+            const holderAccount = generateAccount();
+            const { address: holderAddress } = holderAccount;
+
+            const spender = proxyContract.address;
+            const signature = signPermit(chainID, linkedTokenAddress, holderAccount, spender, nonce, expiry, allowed);
+
+            const { receipt } = await proxyContract.permit(linkedTokenAddress, holderAddress, nonce, signature);
+            expect(receipt.status).to.equal(true);
+
+            const allowance = await dai.allowance.call(holderAddress, spender);
+            expect(allowance.toString()).to.not.equal('0');
+        });
+
+        it('should perform deposit, making use of permit() call, without calling approve()', async () => {
+            const { publicKey, address: holderAddress } = standardAccount;
+
+            // mint DAI tokens
+            const tokensMinted = 500;
+            await dai.mint(holderAddress, tokensMinted, opts);
+
+            const inputNotes = [];
+            const outputNotes = [await note.create(publicKey, 10), await note.create(publicKey, 5)];
+            const publicValue = -15;
+            const sender = proxyContract.address;
+            const publicOwner = proxyContract.address;
+
+            const depositProof = new JoinSplitProof(inputNotes, outputNotes, sender, publicValue, publicOwner);
+            const spender = proxyContract.address;
+            const signature = signPermit(chainID, dai.address, standardAccount, spender, nonce, expiry, allowed);
+
+            expect((await dai.balanceOf(holderAddress)).toNumber()).to.equal(tokensMinted);
+            expect((await dai.balanceOf(ace.address)).toNumber()).to.equal(0);
+            expect((await dai.balanceOf(proxyContract.address)).toNumber()).to.equal(0);
+
+            // Note: No er20.approve() is being made, relying on permit() call in deposit() instead
+            const proofData = depositProof.encodeABI(zkAsset.address);
+            const proofHash = depositProof.hash;
+            const depositAmount = publicValue * -1;
+
+            const { receipt } = await proxyContract.deposit(
+                zkAsset.address,
+                holderAddress,
+                proofHash,
+                proofData,
+                depositAmount,
+                signature,
+                nonce,
+                { from: holderAddress },
+            );
+            expect(receipt.status).to.equal(true);
+            expect((await dai.balanceOf(holderAddress)).toNumber()).to.equal(tokensMinted - depositAmount);
+            expect((await dai.balanceOf(ace.address)).toNumber()).to.equal(depositAmount);
+            expect((await dai.balanceOf(proxyContract.address)).toNumber()).to.equal(0);
+        });
+    });
+
+    describe('Failure states', async () => {
+        it('should fail to perform deposit if permit signature is fake', async () => {
+            const { publicKey, address: holderAddress } = standardAccount;
+
+            // mint DAI tokens
+            const tokensMinted = 500;
+            await dai.mint(holderAddress, tokensMinted, opts);
+
+            const inputNotes = [];
+            const outputNotes = [await note.create(publicKey, 10), await note.create(publicKey, 5)];
+            const publicValue = -15;
+            const sender = proxyContract.address;
+            const publicOwner = proxyContract.address;
+
+            const depositProof = new JoinSplitProof(inputNotes, outputNotes, sender, publicValue, publicOwner);
+            const signature = randomHex(65);
+
+            expect((await dai.balanceOf(holderAddress)).toNumber()).to.equal(tokensMinted);
+            expect((await dai.balanceOf(ace.address)).toNumber()).to.equal(0);
+            expect((await dai.balanceOf(proxyContract.address)).toNumber()).to.equal(0);
+
+            // Note: No er20.approve() is being made, relying on permit() call in deposit() instead
+            const proofData = depositProof.encodeABI(zkAsset.address);
+            const proofHash = depositProof.hash;
+            const depositAmount = publicValue * -1;
+
+            await truffleAssert.reverts(
+                proxyContract.deposit(zkAsset.address, holderAddress, proofHash, proofData, depositAmount, signature, nonce, {
+                    from: holderAddress,
+                }),
+                'Dai/invalid-permit',
+            );
+        });
+    });
+});

--- a/packages/protocol/test/AccountRegistry/epochs/20200220/Behaviour20200220.js
+++ b/packages/protocol/test/AccountRegistry/epochs/20200220/Behaviour20200220.js
@@ -5,7 +5,6 @@ const {
     signer: { signPermit },
 } = require('aztec.js');
 const { generateAccount } = require('@aztec/secp256k1');
-const BN = require('bn.js');
 const truffleAssert = require('truffle-assertions');
 const { randomHex } = require('web3-utils');
 
@@ -18,7 +17,7 @@ const ZkAsset = artifacts.require('ZkAssetOwnable');
 
 const standardAccount = require('../../../helpers/getOwnerAccount');
 
-contract('Behaviour20200220', async (accounts) => {
+contract.only('Behaviour20200220', async (accounts) => {
     let behaviour20200220;
     let manager;
     let proxyContract;
@@ -31,16 +30,13 @@ contract('Behaviour20200220', async (accounts) => {
 
     // Signature params
     const chainID = 4;
-    const nonce = 1;
+    const nonce = 0;
     const expiry = -1; // a massive number in the contract
     const allowed = true;
 
     beforeEach(async () => {
         ace = await ACE.deployed();
-
-        // deploy DAI contract
         dai = await DAI.new(chainID, opts);
-
         zkAsset = await ZkAsset.new(ace.address, dai.address, 1, {
             from: accounts[2],
         });

--- a/packages/protocol/test/AccountRegistry/epochs/20200220/Behaviour20200220.js
+++ b/packages/protocol/test/AccountRegistry/epochs/20200220/Behaviour20200220.js
@@ -6,18 +6,18 @@ const {
 } = require('aztec.js');
 const { generateAccount } = require('@aztec/secp256k1');
 const truffleAssert = require('truffle-assertions');
-const { randomHex } = require('web3-utils');
+const { randomHex, toChecksumAddress } = require('web3-utils');
 
 const ACE = artifacts.require('./ACE');
 const AccountRegistryManager = artifacts.require('./AccountRegistry/AccountRegistryManager');
 const Behaviour20200106 = artifacts.require('./Behaviour20200106/epochs/20200106/Behaviour20200106');
 const Behaviour20200220 = artifacts.require('./Behaviour20200106/epochs/20200106/Behaviour20200220');
-const DAI = artifacts.require('./test/ERC20/DAI/dai');
+const DAI = artifacts.require('./test/ERC20/DAI/Dai');
 const ZkAsset = artifacts.require('ZkAssetOwnable');
 
 const standardAccount = require('../../../helpers/getOwnerAccount');
 
-contract.only('Behaviour20200220', async (accounts) => {
+contract('Behaviour20200220', async (accounts) => {
     let behaviour20200220;
     let manager;
     let proxyContract;
@@ -30,9 +30,6 @@ contract.only('Behaviour20200220', async (accounts) => {
 
     // Signature params
     const chainID = 4;
-    const nonce = 0;
-    const expiry = -1; // a massive number in the contract
-    const allowed = true;
 
     beforeEach(async () => {
         ace = await ACE.deployed();
@@ -69,8 +66,12 @@ contract.only('Behaviour20200220', async (accounts) => {
 
     describe('Success states', async () => {
         it('should update allowance using direct DAI.permit() call', async () => {
+            const nonce = 0;
+            const expiry = -1; // a massive number in the contract
+            const allowed = true;
+
             const holderAccount = generateAccount();
-            const { address: holderAddress } = holderAccount;
+            const { address: userAddress } = holderAccount;
             const spender = randomHex(20);
             const verifyingContract = dai.address;
 
@@ -80,34 +81,76 @@ contract.only('Behaviour20200220', async (accounts) => {
             const s = `0x${permitSig.slice(64, 128)}`;
             const v = `0x${permitSig.slice(128, 130)}`;
 
-            const { receipt } = await dai.permit(holderAddress, spender, nonce, expiry, allowed, v, r, s);
+            const { receipt } = await dai.permit(userAddress, spender, nonce, expiry, allowed, v, r, s);
             expect(receipt.status).to.equal(true);
 
-            const allowance = await dai.allowance.call(holderAddress, spender);
+            const allowance = await dai.allowance.call(userAddress, spender);
             expect(allowance.toString()).to.not.equal('0');
         });
 
+        it('should emit Approval event when permit() is called', async () => {
+            const nonce = 0;
+            const expiry = -1; // a massive number in the contract
+            const allowed = true;
+
+            const holderAccount = generateAccount();
+            const { address: userAddress } = holderAccount;
+            const spender = randomHex(20);
+            const verifyingContract = dai.address;
+
+            const permitSig = signPermit(chainID, verifyingContract, holderAccount, spender, nonce, expiry, allowed).slice(2);
+
+            const r = `0x${permitSig.slice(0, 64)}`;
+            const s = `0x${permitSig.slice(64, 128)}`;
+            const v = `0x${permitSig.slice(128, 130)}`;
+
+            const { receipt } = await dai.permit(userAddress, spender, nonce, expiry, allowed, v, r, s);
+            const event = receipt.logs.find((l) => l.event === 'Approval');
+
+            const emittedUserAddress = event.args.src;
+            const emittedSpenderAddress = event.args.guy;
+
+            expect(emittedUserAddress).to.equal(toChecksumAddress(userAddress));
+            expect(emittedSpenderAddress).to.equal(toChecksumAddress(spender));
+        });
+
         it('should update allowance using indirect proxyContract.permit() call', async () => {
+            const nonce = 0;
+            const expiry = -1; // a massive number in the contract
+            const allowed = true;
+
             const linkedTokenAddress = dai.address;
             const holderAccount = generateAccount();
-            const { address: holderAddress } = holderAccount;
+            const { address: userAddress } = holderAccount;
 
             const spender = proxyContract.address;
             const signature = signPermit(chainID, linkedTokenAddress, holderAccount, spender, nonce, expiry, allowed);
 
-            const { receipt } = await proxyContract.permit(linkedTokenAddress, holderAddress, nonce, signature);
+            const { receipt } = await proxyContract.permit(
+                linkedTokenAddress,
+                userAddress,
+                nonce,
+                allowed,
+                expiry,
+                spender,
+                signature,
+            );
             expect(receipt.status).to.equal(true);
 
-            const allowance = await dai.allowance.call(holderAddress, spender);
+            const allowance = await dai.allowance.call(userAddress, spender);
             expect(allowance.toString()).to.not.equal('0');
         });
 
         it('should perform deposit, making use of permit() call, without calling approve()', async () => {
-            const { publicKey, address: holderAddress } = standardAccount;
+            const nonce = 0;
+            const expiry = -1; // a massive number in the contract
+            const allowed = true;
+
+            const { publicKey, address: userAddress } = standardAccount;
 
             // mint DAI tokens
             const tokensMinted = 500;
-            await dai.mint(holderAddress, tokensMinted, opts);
+            await dai.mint(userAddress, tokensMinted, opts);
 
             const inputNotes = [];
             const outputNotes = [await note.create(publicKey, 10), await note.create(publicKey, 5)];
@@ -119,7 +162,7 @@ contract.only('Behaviour20200220', async (accounts) => {
             const spender = proxyContract.address;
             const signature = signPermit(chainID, dai.address, standardAccount, spender, nonce, expiry, allowed);
 
-            expect((await dai.balanceOf(holderAddress)).toNumber()).to.equal(tokensMinted);
+            expect((await dai.balanceOf(userAddress)).toNumber()).to.equal(tokensMinted);
             expect((await dai.balanceOf(ace.address)).toNumber()).to.equal(0);
             expect((await dai.balanceOf(proxyContract.address)).toNumber()).to.equal(0);
 
@@ -128,18 +171,54 @@ contract.only('Behaviour20200220', async (accounts) => {
             const proofHash = depositProof.hash;
             const depositAmount = publicValue * -1;
 
-            const { receipt } = await proxyContract.deposit(
+            const { receipt } = await proxyContract.methods[
+                'deposit(address,address,bytes32,bytes,uint256,bytes,uint256)'
+            ](zkAsset.address, userAddress, proofHash, proofData, depositAmount, signature, nonce, { from: userAddress });
+
+            expect(receipt.status).to.equal(true);
+            expect((await dai.balanceOf(userAddress)).toNumber()).to.equal(tokensMinted - depositAmount);
+            expect((await dai.balanceOf(ace.address)).toNumber()).to.equal(depositAmount);
+            expect((await dai.balanceOf(proxyContract.address)).toNumber()).to.equal(0);
+        });
+
+        it('should be able to call old Behaviour20200106.deposit() function for alternative approve flow', async () => {
+            const { publicKey, address: userAddress } = standardAccount;
+
+            // mint DAI tokens
+            const tokensMinted = 500;
+            await dai.mint(userAddress, tokensMinted, opts);
+
+            const inputNotes = [];
+            const outputNotes = [await note.create(publicKey, 10), await note.create(publicKey, 5)];
+            const publicValue = -15;
+            const sender = proxyContract.address;
+            const publicOwner = proxyContract.address;
+
+            const depositProof = new JoinSplitProof(inputNotes, outputNotes, sender, publicValue, publicOwner);
+
+            expect((await dai.balanceOf(userAddress)).toNumber()).to.equal(tokensMinted);
+            expect((await dai.balanceOf(ace.address)).toNumber()).to.equal(0);
+            expect((await dai.balanceOf(proxyContract.address)).toNumber()).to.equal(0);
+
+            // Note: No er20.approve() is being made, relying on permit() call in deposit() instead
+            const proofData = depositProof.encodeABI(zkAsset.address);
+            const proofHash = depositProof.hash;
+            const depositAmount = publicValue * -1;
+
+            // legacy flow - call dai.approve()
+            await dai.approve(proxyContract.address, depositAmount, { from: userAddress });
+
+            const { receipt } = await proxyContract.methods['deposit(address,address,bytes32,bytes,uint256)'](
                 zkAsset.address,
-                holderAddress,
+                userAddress,
                 proofHash,
                 proofData,
                 depositAmount,
-                signature,
-                nonce,
-                { from: holderAddress },
+                { from: userAddress },
             );
+
             expect(receipt.status).to.equal(true);
-            expect((await dai.balanceOf(holderAddress)).toNumber()).to.equal(tokensMinted - depositAmount);
+            expect((await dai.balanceOf(userAddress)).toNumber()).to.equal(tokensMinted - depositAmount);
             expect((await dai.balanceOf(ace.address)).toNumber()).to.equal(depositAmount);
             expect((await dai.balanceOf(proxyContract.address)).toNumber()).to.equal(0);
         });
@@ -147,11 +226,12 @@ contract.only('Behaviour20200220', async (accounts) => {
 
     describe('Failure states', async () => {
         it('should fail to perform deposit if permit signature is fake', async () => {
-            const { publicKey, address: holderAddress } = standardAccount;
+            const nonce = 0;
+            const { publicKey, address: userAddress } = standardAccount;
 
             // mint DAI tokens
             const tokensMinted = 500;
-            await dai.mint(holderAddress, tokensMinted, opts);
+            await dai.mint(userAddress, tokensMinted, opts);
 
             const inputNotes = [];
             const outputNotes = [await note.create(publicKey, 10), await note.create(publicKey, 5)];
@@ -162,20 +242,70 @@ contract.only('Behaviour20200220', async (accounts) => {
             const depositProof = new JoinSplitProof(inputNotes, outputNotes, sender, publicValue, publicOwner);
             const signature = randomHex(65);
 
-            expect((await dai.balanceOf(holderAddress)).toNumber()).to.equal(tokensMinted);
+            expect((await dai.balanceOf(userAddress)).toNumber()).to.equal(tokensMinted);
             expect((await dai.balanceOf(ace.address)).toNumber()).to.equal(0);
             expect((await dai.balanceOf(proxyContract.address)).toNumber()).to.equal(0);
 
-            // Note: No er20.approve() is being made, relying on permit() call in deposit() instead
             const proofData = depositProof.encodeABI(zkAsset.address);
             const proofHash = depositProof.hash;
             const depositAmount = publicValue * -1;
 
             await truffleAssert.reverts(
-                proxyContract.deposit(zkAsset.address, holderAddress, proofHash, proofData, depositAmount, signature, nonce, {
-                    from: holderAddress,
-                }),
+                proxyContract.methods['deposit(address,address,bytes32,bytes,uint256,bytes,uint256)'](
+                    zkAsset.address,
+                    userAddress,
+                    proofHash,
+                    proofData,
+                    depositAmount,
+                    signature,
+                    nonce,
+                    { from: userAddress },
+                ),
                 'Dai/invalid-permit',
+            );
+        });
+
+        it('should fail to perform deposit if nonce is incorrect', async () => {
+            // incorrect nonce is defined as one which != nonces[user]++
+            const nonce = 5;
+            const expiry = -1; // a massive number in the contract
+            const allowed = true;
+            const { publicKey, address: userAddress } = standardAccount;
+
+            // mint DAI tokens
+            const tokensMinted = 500;
+            await dai.mint(userAddress, tokensMinted, opts);
+
+            const inputNotes = [];
+            const outputNotes = [await note.create(publicKey, 10), await note.create(publicKey, 5)];
+            const publicValue = -15;
+            const sender = proxyContract.address;
+            const publicOwner = proxyContract.address;
+
+            const depositProof = new JoinSplitProof(inputNotes, outputNotes, sender, publicValue, publicOwner);
+            const spender = proxyContract.address;
+            const signature = signPermit(chainID, dai.address, standardAccount, spender, nonce, expiry, allowed);
+
+            expect((await dai.balanceOf(userAddress)).toNumber()).to.equal(tokensMinted);
+            expect((await dai.balanceOf(ace.address)).toNumber()).to.equal(0);
+            expect((await dai.balanceOf(proxyContract.address)).toNumber()).to.equal(0);
+
+            const proofData = depositProof.encodeABI(zkAsset.address);
+            const proofHash = depositProof.hash;
+            const depositAmount = publicValue * -1;
+
+            await truffleAssert.reverts(
+                proxyContract.methods['deposit(address,address,bytes32,bytes,uint256,bytes,uint256)'](
+                    zkAsset.address,
+                    userAddress,
+                    proofHash,
+                    proofData,
+                    depositAmount,
+                    signature,
+                    nonce,
+                    { from: userAddress },
+                ),
+                'Dai/invalid-nonce',
             );
         });
     });

--- a/packages/protocol/test/helpers/AccountRegistry/epochs/20200106/Behaviour20200106.js
+++ b/packages/protocol/test/helpers/AccountRegistry/epochs/20200106/Behaviour20200106.js
@@ -1,21 +1,10 @@
 const { ProofUtils, note } = require('aztec.js');
-const secp256k1 = require('@aztec/secp256k1');
-const bip39 = require('bip39');
-const dotenv = require('dotenv');
-const hdkey = require('ethereumjs-wallet/hdkey');
+const { publicKey: standardPubKey, privateKey } = require('../../../getOwnerAccount');
 
-dotenv.config();
-const mnemonic = process.env.TEST_MNEMONIC;
-const seed = bip39.mnemonicToSeed(mnemonic);
-const hdwallet = hdkey.fromMasterSeed(seed);
-
-const noteOwnerWallet = hdwallet.derivePath("m/44'/60'/0'/0/0").getWallet();
-const noteOwnerAccount = secp256k1.accountFromPrivateKey(noteOwnerWallet.getPrivateKeyString());
-
-const generateOutputNotes = async (values, publicKey = noteOwnerAccount.publicKey) =>
+const generateOutputNotes = async (values, publicKey = standardPubKey) =>
     Promise.all(values.map(async (value) => note.create(publicKey, value)));
 
-const generateDepositProofInputs = async ({ outputNoteValues = [20, 30], publicKey = noteOwnerAccount.publicKey } = {}) => {
+const generateDepositProofInputs = async ({ outputNoteValues = [20, 30], publicKey = standardPubKey } = {}) => {
     const inputNotes = [];
     const outputNotes = await generateOutputNotes(outputNoteValues, publicKey);
 
@@ -32,7 +21,7 @@ const generateDepositProofInputs = async ({ outputNoteValues = [20, 30], publicK
 };
 
 const getOwnerPrivateKey = () => {
-    return noteOwnerAccount.privateKey;
+    return privateKey;
 };
 
 module.exports = {

--- a/packages/protocol/test/helpers/getOwnerAccount.js
+++ b/packages/protocol/test/helpers/getOwnerAccount.js
@@ -1,0 +1,18 @@
+const secp256k1 = require('@aztec/secp256k1');
+const bip39 = require('bip39');
+const dotenv = require('dotenv');
+const hdkey = require('ethereumjs-wallet/hdkey');
+
+dotenv.config();
+const mnemonic = process.env.TEST_MNEMONIC;
+const seed = bip39.mnemonicToSeed(mnemonic);
+const hdwallet = hdkey.fromMasterSeed(seed);
+
+const noteOwnerWallet = hdwallet.derivePath("m/44'/60'/0'/0/0").getWallet();
+const { address, privateKey, publicKey } = secp256k1.accountFromPrivateKey(noteOwnerWallet.getPrivateKeyString());
+
+module.exports = {
+    address,
+    privateKey,
+    publicKey,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,30 +232,31 @@
   dependencies:
     lodash "^4.17.11"
 
-"@aztec/guacamole-ui@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@aztec/guacamole-ui/-/guacamole-ui-1.1.3.tgz#df43b350842a0e3239ab30528217bd56ba6deac9"
-  integrity sha512-jgnwAaVhRBwYjz6iDNLwiCblFUnKbaj/oGLspE+A4q7xOZOWENPGbEyHK5O/hKdZ6rOu1vpw4kjlBgGLK4LhGQ==
+"@aztec/guacamole-ui@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/guacamole-ui/-/guacamole-ui-1.2.0.tgz#a59d8502b2ae7ea5151a8b8d3fdd61fbf69f7a14"
+  integrity sha512-eq7ClBy0QEg6Wg+3hPTCLKjigjCkyslUqs4PJIiOCEusybNUWD24V2rMACvT+myi03y7nh+O/9frehaFI7A8qQ==
   dependencies:
-    "@babel/core" "^7.4.0"
-    "@babel/node" "^7.2.2"
-    "@babel/plugin-proposal-class-properties" "^7.4.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.4.0"
-    "@babel/preset-env" "^7.4.2"
-    "@babel/preset-react" "^7.0.0"
+    "@babel/core" "^7.8.4"
+    "@babel/node" "^7.8.4"
+    "@babel/plugin-proposal-class-properties" "^7.8.3"
+    "@babel/plugin-proposal-object-rest-spread" "^7.8.3"
+    "@babel/preset-env" "^7.8.4"
+    "@babel/preset-react" "^7.8.3"
     autoprefixer "^9.5.0"
-    babel-loader "^8.0.5"
-    chalk "^2.4.2"
+    babel-loader "^8.0.6"
+    babel-plugin-react-css-modules "^5.2.6"
+    chalk "^3.0.0"
     classnames "^2.2.6"
-    css-loader "^2.1.1"
-    del "^4.0.0"
-    file-loader "^3.0.1"
+    css-loader "^3.4.2"
+    del "^5.1.0"
+    file-loader "^5.0.2"
     ignore-loader "^0.1.2"
     loader-utils "^1.2.3"
     lodash "^4.17.11"
     md5 "^2.2.1"
-    memory-fs "^0.4.1"
-    mini-css-extract-plugin "^0.5.0"
+    memory-fs "^0.5.0"
+    mini-css-extract-plugin "^0.9.0"
     moment "^2.24.0"
     mri "^1.1.4"
     node-sass "^4.11.0"
@@ -264,9 +265,8 @@
     postcss-loader "^3.0.0"
     prop-types "^15.7.2"
     react "^16.8.4"
-    react-css-modules "^4.7.9"
     react-custom-scrollbars "^4.2.1"
-    react-dev-utils "^8.0.0"
+    react-dev-utils "^10.1.0"
     react-dom "^16.8.4"
     resolve-url-loader "^3.0.1"
     sass-loader "^8.0.0"
@@ -298,13 +298,6 @@
   optionalDependencies:
     chokidar "^2.1.8"
 
-"@babel/code-frame@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
-  integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
-  dependencies:
-    "@babel/highlight" "^7.0.0"
-
 "@babel/code-frame@7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -312,7 +305,7 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.35", "@babel/code-frame@^7.0.0-beta.36", "@babel/code-frame@^7.8.3":
+"@babel/code-frame@7.8.3", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.35", "@babel/code-frame@^7.0.0-beta.36", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
   integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
@@ -325,6 +318,15 @@
   integrity sha512-Z+6ZOXvyOWYxJ50BwxzdhRnRsGST8Y3jaZgxYig575lTjVSs3KtJnmESwZegg6e2Dn0td1eDhoWlp1wI4BTCPw==
   dependencies:
     browserslist "^4.8.2"
+    invariant "^2.2.4"
+    semver "^5.5.0"
+
+"@babel/compat-data@^7.8.4":
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.8.5.tgz#d28ce872778c23551cbb9432fc68d28495b613b9"
+  integrity sha512-jWYUqQX/ObOhG1UiEkbH5SANsE/8oKXiQWjj7p7xgj9Zmnt//aUvyz4dBkK0HNsS8/cbyC5NmmH87VekW+mXFg==
+  dependencies:
+    browserslist "^4.8.5"
     invariant "^2.2.4"
     semver "^5.5.0"
 
@@ -349,10 +351,41 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.8.4.tgz#d496799e5c12195b3602d0fddd77294e3e38e80e"
+  integrity sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.8.4"
+    "@babel/helpers" "^7.8.4"
+    "@babel/parser" "^7.8.4"
+    "@babel/template" "^7.8.3"
+    "@babel/traverse" "^7.8.4"
+    "@babel/types" "^7.8.3"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.4.0", "@babel/generator@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.3.tgz#0e22c005b0a94c1c74eafe19ef78ce53a4d45c03"
   integrity sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==
+  dependencies:
+    "@babel/types" "^7.8.3"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.4.tgz#35bbc74486956fe4251829f9f6c48330e8d0985e"
+  integrity sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==
   dependencies:
     "@babel/types" "^7.8.3"
     jsesc "^2.5.1"
@@ -400,6 +433,17 @@
     browserslist "^4.8.2"
     invariant "^2.2.4"
     levenary "^1.1.0"
+    semver "^5.5.0"
+
+"@babel/helper-compilation-targets@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.4.tgz#03d7ecd454b7ebe19a254f76617e61770aed2c88"
+  integrity sha512-3k3BsKMvPp5bjxgMdrFyq0UaEO48HciVrOVF0+lon8pp95cyJ2ujAh0TrBHNMnJGT2rr0iKOJPFFbSqjDyf/Pg==
+  dependencies:
+    "@babel/compat-data" "^7.8.4"
+    browserslist "^4.8.5"
+    invariant "^2.2.4"
+    levenary "^1.1.1"
     semver "^5.5.0"
 
 "@babel/helper-create-class-features-plugin@^7.8.3":
@@ -562,6 +606,15 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helpers@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.8.4.tgz#754eb3ee727c165e0a240d6c207de7c455f36f73"
+  integrity sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==
+  dependencies:
+    "@babel/template" "^7.8.3"
+    "@babel/traverse" "^7.8.4"
+    "@babel/types" "^7.8.3"
+
 "@babel/highlight@^7.0.0", "@babel/highlight@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.8.3.tgz#28f173d04223eaaa59bc1d439a3836e6d1265797"
@@ -585,10 +638,29 @@
     resolve "^1.13.1"
     v8flags "^3.1.1"
 
+"@babel/node@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/node/-/node-7.8.4.tgz#59b2ed7e5a9df2224592f83292d77d616fbf1ab8"
+  integrity sha512-MlczXI/VYRnoaWHjicqrzq2z4DhRPaWQIC+C3ISEQs5z+mEccBsn7IAI5Q97ZDTnFYw6ts5IUTzqArilC/g7nw==
+  dependencies:
+    "@babel/register" "^7.8.3"
+    commander "^4.0.1"
+    core-js "^3.2.1"
+    lodash "^4.17.13"
+    node-environment-flags "^1.0.5"
+    regenerator-runtime "^0.13.3"
+    resolve "^1.13.1"
+    v8flags "^3.1.1"
+
 "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.4.4", "@babel/parser@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.3.tgz#790874091d2001c9be6ec426c2eed47bc7679081"
   integrity sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==
+
+"@babel/parser@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.4.tgz#d1dbe64691d60358a974295fa53da074dd2ce8e8"
+  integrity sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==
 
 "@babel/plugin-proposal-async-generator-functions@^7.8.3":
   version "7.8.3"
@@ -599,7 +671,7 @@
     "@babel/helper-remap-async-to-generator" "^7.8.3"
     "@babel/plugin-syntax-async-generators" "^7.8.0"
 
-"@babel/plugin-proposal-class-properties@^7.4.0", "@babel/plugin-proposal-class-properties@^7.4.4", "@babel/plugin-proposal-class-properties@^7.5.5":
+"@babel/plugin-proposal-class-properties@^7.4.4", "@babel/plugin-proposal-class-properties@^7.5.5", "@babel/plugin-proposal-class-properties@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz#5e06654af5cd04b608915aada9b2a6788004464e"
   integrity sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==
@@ -684,7 +756,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.8.3":
+"@babel/plugin-syntax-jsx@^7.0.0", "@babel/plugin-syntax-jsx@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.8.3.tgz#521b06c83c40480f1e58b4fd33b92eceb1d6ea94"
   integrity sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==
@@ -815,6 +887,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
+"@babel/plugin-transform-for-of@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.4.tgz#6fe8eae5d6875086ee185dd0b098a8513783b47d"
+  integrity sha512-iAXNlOWvcYUYoV8YIxwS7TxGRJcxyl8eQCfT+A5j8sKUzRFvJdcyjp97jL2IghWSRDaL2PU2O2tX8Cu9dTBq5A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+
 "@babel/plugin-transform-function-name@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz#279373cb27322aaad67c2683e776dfc47196ed8b"
@@ -900,6 +979,15 @@
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.3.tgz#7890576a13b17325d8b7d44cb37f21dc3bbdda59"
   integrity sha512-/pqngtGb54JwMBZ6S/D3XYylQDFtGjWrnoCF4gXZOUpFV/ujbxnoNGNvDGu6doFWRPBveE72qTx/RRU44j5I/Q==
+  dependencies:
+    "@babel/helper-call-delegate" "^7.8.3"
+    "@babel/helper-get-function-arity" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-transform-parameters@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.4.tgz#1d5155de0b65db0ccf9971165745d3bb990d77d3"
+  integrity sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==
   dependencies:
     "@babel/helper-call-delegate" "^7.8.3"
     "@babel/helper-get-function-arity" "^7.8.3"
@@ -1005,6 +1093,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
+"@babel/plugin-transform-typeof-symbol@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz#ede4062315ce0aaf8a657a920858f1a2f35fc412"
+  integrity sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+
 "@babel/plugin-transform-unicode-regex@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz#0cef36e3ba73e5c57273effb182f46b91a1ecaad"
@@ -1084,7 +1179,70 @@
     levenary "^1.1.0"
     semver "^5.5.0"
 
-"@babel/preset-react@^7.0.0":
+"@babel/preset-env@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.8.4.tgz#9dac6df5f423015d3d49b6e9e5fa3413e4a72c4e"
+  integrity sha512-HihCgpr45AnSOHRbS5cWNTINs0TwaR8BS8xIIH+QwiW8cKL0llV91njQMpeMReEPVs+1Ao0x3RLEBLtt1hOq4w==
+  dependencies:
+    "@babel/compat-data" "^7.8.4"
+    "@babel/helper-compilation-targets" "^7.8.4"
+    "@babel/helper-module-imports" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-proposal-async-generator-functions" "^7.8.3"
+    "@babel/plugin-proposal-dynamic-import" "^7.8.3"
+    "@babel/plugin-proposal-json-strings" "^7.8.3"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-proposal-object-rest-spread" "^7.8.3"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-proposal-optional-chaining" "^7.8.3"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.8.3"
+    "@babel/plugin-syntax-async-generators" "^7.8.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
+    "@babel/plugin-syntax-json-strings" "^7.8.0"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+    "@babel/plugin-syntax-top-level-await" "^7.8.3"
+    "@babel/plugin-transform-arrow-functions" "^7.8.3"
+    "@babel/plugin-transform-async-to-generator" "^7.8.3"
+    "@babel/plugin-transform-block-scoped-functions" "^7.8.3"
+    "@babel/plugin-transform-block-scoping" "^7.8.3"
+    "@babel/plugin-transform-classes" "^7.8.3"
+    "@babel/plugin-transform-computed-properties" "^7.8.3"
+    "@babel/plugin-transform-destructuring" "^7.8.3"
+    "@babel/plugin-transform-dotall-regex" "^7.8.3"
+    "@babel/plugin-transform-duplicate-keys" "^7.8.3"
+    "@babel/plugin-transform-exponentiation-operator" "^7.8.3"
+    "@babel/plugin-transform-for-of" "^7.8.4"
+    "@babel/plugin-transform-function-name" "^7.8.3"
+    "@babel/plugin-transform-literals" "^7.8.3"
+    "@babel/plugin-transform-member-expression-literals" "^7.8.3"
+    "@babel/plugin-transform-modules-amd" "^7.8.3"
+    "@babel/plugin-transform-modules-commonjs" "^7.8.3"
+    "@babel/plugin-transform-modules-systemjs" "^7.8.3"
+    "@babel/plugin-transform-modules-umd" "^7.8.3"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.8.3"
+    "@babel/plugin-transform-new-target" "^7.8.3"
+    "@babel/plugin-transform-object-super" "^7.8.3"
+    "@babel/plugin-transform-parameters" "^7.8.4"
+    "@babel/plugin-transform-property-literals" "^7.8.3"
+    "@babel/plugin-transform-regenerator" "^7.8.3"
+    "@babel/plugin-transform-reserved-words" "^7.8.3"
+    "@babel/plugin-transform-shorthand-properties" "^7.8.3"
+    "@babel/plugin-transform-spread" "^7.8.3"
+    "@babel/plugin-transform-sticky-regex" "^7.8.3"
+    "@babel/plugin-transform-template-literals" "^7.8.3"
+    "@babel/plugin-transform-typeof-symbol" "^7.8.4"
+    "@babel/plugin-transform-unicode-regex" "^7.8.3"
+    "@babel/types" "^7.8.3"
+    browserslist "^4.8.5"
+    core-js-compat "^3.6.2"
+    invariant "^2.2.2"
+    levenary "^1.1.1"
+    semver "^5.5.0"
+
+"@babel/preset-react@^7.0.0", "@babel/preset-react@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.8.3.tgz#23dc63f1b5b0751283e04252e78cf1d6589273d2"
   integrity sha512-9hx0CwZg92jGb7iHYQVgi0tOEHP/kM60CtWJQnmbATSPIQQ2xYzfoCI3EdqAhFBeeJwYMdWQuDUHMsuDbH9hyQ==
@@ -1140,6 +1298,21 @@
     "@babel/helper-function-name" "^7.8.3"
     "@babel/helper-split-export-declaration" "^7.8.3"
     "@babel/parser" "^7.8.3"
+    "@babel/types" "^7.8.3"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
+"@babel/traverse@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.4.tgz#f0845822365f9d5b0e312ed3959d3f827f869e3c"
+  integrity sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.8.4"
+    "@babel/helper-function-name" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.8.4"
     "@babel/types" "^7.8.3"
     debug "^4.1.0"
     globals "^11.1.0"
@@ -3760,11 +3933,6 @@ add-px-to-style@1.0.0:
   resolved "https://registry.yarnpkg.com/add-px-to-style/-/add-px-to-style-1.0.0.tgz#d0c135441fa8014a8137904531096f67f28f263a"
   integrity sha1-0ME1RB+oAUqBN5BFMQlvZ/KPJjo=
 
-address@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/address/-/address-1.0.3.tgz#b5f50631f8d6cec8bd20c963963afb55e06cbce9"
-  integrity sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==
-
 address@1.1.2, address@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
@@ -3830,7 +3998,7 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
-ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
+ajv-keywords@^3.1.0, ajv-keywords@^3.2.0, ajv-keywords@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
@@ -3889,6 +4057,13 @@ ansi-escapes@^3.0.0, ansi-escapes@^3.1.0, ansi-escapes@^3.2.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
+ansi-escapes@^4.2.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.0.tgz#a4ce2b33d6b214b7950d8595c212f12ac9cc569d"
+  integrity sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==
+  dependencies:
+    type-fest "^0.8.1"
+
 ansi-gray@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ansi-gray/-/ansi-gray-0.1.1.tgz#2962cf54ec9792c48510a3deb524436861ef7251"
@@ -3933,7 +4108,7 @@ ansi-styles@^3.0.0, ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
   integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
@@ -4183,11 +4358,6 @@ array-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
 
-array-filter@~0.0.0:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
-  integrity sha1-fajPLiZijtcygDWB/SH2fKzS7uw=
-
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
@@ -4236,16 +4406,6 @@ array-last@^1.1.1:
   integrity sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==
   dependencies:
     is-number "^4.0.0"
-
-array-map@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
-  integrity sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=
-
-array-reduce@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
-  integrity sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=
 
 array-slice@^1.0.0:
   version "1.1.0"
@@ -4796,6 +4956,24 @@ babel-plugin-module-resolver@^3.2.0:
     pkg-up "^2.0.0"
     reselect "^3.0.1"
     resolve "^1.4.0"
+
+babel-plugin-react-css-modules@^5.2.6:
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-css-modules/-/babel-plugin-react-css-modules-5.2.6.tgz#176663dae4add31af780f1ec86d3a93115875c83"
+  integrity sha512-jBU/oVgoEg/58Dcu0tjyNvaXBllxJXip7hlpiX+e0CYTmDADWB484P4pJb7d0L6nWKSzyEqtePcBaq3SKalG/g==
+  dependencies:
+    "@babel/plugin-syntax-jsx" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    ajv "^6.5.3"
+    ajv-keywords "^3.2.0"
+    generic-names "^2.0.1"
+    postcss "^7.0.2"
+    postcss-modules "^1.3.2"
+    postcss-modules-extract-imports "^1.2.0"
+    postcss-modules-local-by-default "^1.2.0"
+    postcss-modules-parser "^1.1.1"
+    postcss-modules-scope "^1.1.0"
+    postcss-modules-values "^1.3.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -5642,15 +5820,6 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.4.1.tgz#42e828954b6b29a7a53e352277be429478a69062"
-  integrity sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==
-  dependencies:
-    caniuse-lite "^1.0.30000929"
-    electron-to-chromium "^1.3.103"
-    node-releases "^1.1.3"
-
 browserslist@4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.7.0.tgz#9ee89225ffc07db03409f2fee524dc8227458a17"
@@ -5659,6 +5828,15 @@ browserslist@4.7.0:
     caniuse-lite "^1.0.30000989"
     electron-to-chromium "^1.3.247"
     node-releases "^1.1.29"
+
+browserslist@4.8.6:
+  version "4.8.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.6.tgz#96406f3f5f0755d272e27a66f4163ca821590a7e"
+  integrity sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==
+  dependencies:
+    caniuse-lite "^1.0.30001023"
+    electron-to-chromium "^1.3.341"
+    node-releases "^1.1.47"
 
 browserslist@^3.2.6:
   version "3.2.8"
@@ -5676,6 +5854,15 @@ browserslist@^4.0.0, browserslist@^4.8.2, browserslist@^4.8.3:
     caniuse-lite "^1.0.30001022"
     electron-to-chromium "^1.3.338"
     node-releases "^1.1.46"
+
+browserslist@^4.8.5:
+  version "4.8.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.7.tgz#ec8301ff415e6a42c949d0e66b405eb539c532d0"
+  integrity sha512-gFOnZNYBHrEyUML0xr5NJ6edFaaKbTFX9S9kQHlYfCP0Rit/boRIz4G+Avq6/4haEKJXdGGUnoolx+5MWW2BoA==
+  dependencies:
+    caniuse-lite "^1.0.30001027"
+    electron-to-chromium "^1.3.349"
+    node-releases "^1.1.49"
 
 bs58@^2.0.1:
   version "2.0.1"
@@ -6041,7 +6228,7 @@ camelcase@5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
   integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
 
-camelcase@5.3.1, camelcase@^5.0.0, camelcase@^5.2.0, camelcase@^5.3.1:
+camelcase@5.3.1, camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -6071,10 +6258,15 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001022:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001022:
   version "1.0.30001023"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz#b82155827f3f5009077bdd2df3d8968bcbcc6fc4"
   integrity sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA==
+
+caniuse-lite@^1.0.30001023, caniuse-lite@^1.0.30001027:
+  version "1.0.30001028"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001028.tgz#f2241242ac70e0fa9cda55c2776d32a0867971c2"
+  integrity sha512-Vnrq+XMSHpT7E+LWoIYhs3Sne8h9lx9YJV3acH3THNCwU/9zV93/ta4xVfzTtnqd3rvnuVpVjE3DFqf56tr3aQ==
 
 canvg@1.5.3:
   version "1.5.3"
@@ -6176,6 +6368,14 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -6234,7 +6434,7 @@ chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.4, chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chokidar@^3.0.2:
+chokidar@^3.0.2, chokidar@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
   integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
@@ -6345,7 +6545,7 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-cursor@^3.0.0:
+cli-cursor@^3.0.0, cli-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
   integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
@@ -7175,6 +7375,15 @@ cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@7.0.1, cross-spawn@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
+  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
@@ -7199,15 +7408,6 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-cross-spawn@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
-  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
-  dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
 
 crypt@~0.0.1:
   version "0.0.2"
@@ -7261,24 +7461,7 @@ css-line-break@1.0.1:
   dependencies:
     base64-arraybuffer "^0.1.5"
 
-css-loader@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-2.1.1.tgz#d8254f72e412bb2238bb44dd674ffbef497333ea"
-  integrity sha512-OcKJU/lt232vl1P9EEDamhoO9iKY3tIjY5GU+XDLblAykTdgs6Ux9P1hTHve8nFKy5KPpOXOsVI/hIwi3841+w==
-  dependencies:
-    camelcase "^5.2.0"
-    icss-utils "^4.1.0"
-    loader-utils "^1.2.3"
-    normalize-path "^3.0.0"
-    postcss "^7.0.14"
-    postcss-modules-extract-imports "^2.0.0"
-    postcss-modules-local-by-default "^2.0.6"
-    postcss-modules-scope "^2.1.0"
-    postcss-modules-values "^2.0.0"
-    postcss-value-parser "^3.3.0"
-    schema-utils "^1.0.0"
-
-css-loader@^3.0.0:
+css-loader@^3.0.0, css-loader@^3.4.2:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.4.2.tgz#d3fdb3358b43f233b78501c5ed7b1c6da6133202"
   integrity sha512-jYq4zdZT0oS0Iykt+fqnzVLRIeiPWhka+7BqPn+oSIpWJAHak5tmB/WZrJ2a21JhCeFyNnnlroSl8c+MtVndzA==
@@ -7295,6 +7478,18 @@ css-loader@^3.0.0:
     postcss-modules-values "^3.0.0"
     postcss-value-parser "^4.0.2"
     schema-utils "^2.6.0"
+
+css-modules-loader-core@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/css-modules-loader-core/-/css-modules-loader-core-1.1.0.tgz#5908668294a1becd261ae0a4ce21b0b551f21d16"
+  integrity sha1-WQhmgpShvs0mGuCkziGwtVHyHRY=
+  dependencies:
+    icss-replace-symbols "1.1.0"
+    postcss "6.0.1"
+    postcss-modules-extract-imports "1.1.0"
+    postcss-modules-local-by-default "1.2.0"
+    postcss-modules-scope "1.1.0"
+    postcss-modules-values "1.3.0"
 
 css-select-base-adapter@^0.1.1:
   version "0.1.1"
@@ -7320,6 +7515,15 @@ css-select@^2.0.0:
     css-what "^3.2.1"
     domutils "^1.7.0"
     nth-check "^1.0.2"
+
+css-selector-tokenizer@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz#a177271a8bca5019172f4f891fc6eed9cbf68d5d"
+  integrity sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==
+  dependencies:
+    cssesc "^0.1.0"
+    fastparse "^1.1.1"
+    regexpu-core "^1.0.0"
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -7353,6 +7557,11 @@ css@^2.0.0:
     source-map "^0.6.1"
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
+
+cssesc@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
+  integrity sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=
 
 cssesc@^2.0.0:
   version "2.0.0"
@@ -7829,7 +8038,7 @@ defined@~1.0.0:
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
   integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
 
-del@^4.0.0, del@^4.1.1:
+del@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4"
   integrity sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==
@@ -7841,6 +8050,20 @@ del@^4.0.0, del@^4.1.1:
     p-map "^2.0.0"
     pify "^4.0.1"
     rimraf "^2.6.3"
+
+del@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-5.1.0.tgz#d9487c94e367410e6eff2925ee58c0c84a75b3a7"
+  integrity sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==
+  dependencies:
+    globby "^10.0.1"
+    graceful-fs "^4.2.2"
+    is-glob "^4.0.1"
+    is-path-cwd "^2.2.0"
+    is-path-inside "^3.0.1"
+    p-map "^3.0.0"
+    rimraf "^3.0.0"
+    slash "^3.0.0"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -8275,10 +8498,15 @@ ejs@^2.6.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-electron-to-chromium@^1.3.103, electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.338, electron-to-chromium@^1.3.47:
+electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.338, electron-to-chromium@^1.3.47:
   version "1.3.341"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.341.tgz#ad4c039bf621715a12dd814a95a7d89ec80b092c"
   integrity sha512-iezlV55/tan1rvdvt7yg7VHRSkt+sKfzQ16wTDqTbQqtl4+pSUkKPXpQHDvEt0c7gKcUHHwUbffOgXz6bn096g==
+
+electron-to-chromium@^1.3.341, electron-to-chromium@^1.3.349:
+  version "1.3.355"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.355.tgz#ff805ed8a3d68e550a45955134e4e81adf1122ba"
+  integrity sha512-zKO/wS+2ChI/jz9WAo647xSW8t2RmgRLFdbUb/77cORkUTargO+SCj4ctTHjBn2VeNFrsLgDT7IuDVrd3F8mLQ==
 
 electron@^7.0.0:
   version "7.1.10"
@@ -8352,6 +8580,11 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
   integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
+
+emojis-list@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
+  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
 encodeurl@^1.0.2, encodeurl@~1.0.2:
   version "1.0.2"
@@ -8547,7 +8780,7 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escape-string-regexp@^2.0.0:
+escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
@@ -9672,6 +9905,11 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fastparse@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
+  integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
+
 fastq@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2"
@@ -9755,20 +9993,20 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
-file-loader@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-3.0.1.tgz#f8e0ba0b599918b51adfe45d66d1e771ad560faa"
-  integrity sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==
-  dependencies:
-    loader-utils "^1.0.2"
-    schema-utils "^1.0.0"
-
 file-loader@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-4.3.0.tgz#780f040f729b3d18019f20605f723e844b8a58af"
   integrity sha512-aKrYPYjF1yG3oX0kWRrqrSMfgftm7oJW5M+m4owoldH5C51C0RkIwB++JbRvEW3IU6/ZG5n8UvEcdgwOt2UOWA==
   dependencies:
     loader-utils "^1.2.3"
+    schema-utils "^2.5.0"
+
+file-loader@^5.0.2:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-5.1.0.tgz#cb56c070efc0e40666424309bd0d9e45ac6f2bb8"
+  integrity sha512-u/VkLGskw3Ue59nyOwUwXI/6nuBCo7KBkniB/l7ICwr/7cPNGsL1WCXUp3GB0qgOOKU1TiP49bv4DZF/LJqprg==
+  dependencies:
+    loader-utils "^1.4.0"
     schema-utils "^2.5.0"
 
 file-saver@eligrey/FileSaver.js#1.3.8:
@@ -9812,6 +10050,11 @@ filesize@3.6.1, filesize@^3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"
   integrity sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==
+
+filesize@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-6.0.1.tgz#f850b509909c7c86f7e450ea19006c31c2ed3d2f"
+  integrity sha512-u4AYWPgbI5GBhs6id1KdImZWn5yfyFrrQ8OWZdN7ZMfA8Bf4HcO0BGo9bmUIEV8yrp8I1xVfJ/dn90GtFNNJcg==
 
 fill-range@^2.1.0:
   version "2.2.4"
@@ -9914,6 +10157,14 @@ find-up@3.0.0, find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-up@4.1.0, find-up@^4.0.0, find-up@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -9928,14 +10179,6 @@ find-up@^2.0.0, find-up@^2.1.0:
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
-
-find-up@^4.0.0, find-up@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
-  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
-  dependencies:
-    locate-path "^5.0.0"
-    path-exists "^4.0.0"
 
 find-versions@^3.0.0:
   version "3.2.0"
@@ -10095,19 +10338,6 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-fork-ts-checker-webpack-plugin@1.0.0-alpha.6:
-  version "1.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.0.0-alpha.6.tgz#826c57048addf8a3253853615c84f3ff7beeaf45"
-  integrity sha512-s/V+58nLrUjuXyzYk8AL11XG8bxIirTbafDLMn26sL59HQx8QvvsRTqOkhq4MV0coIkog1jZuH/E9Abm8zFZ2g==
-  dependencies:
-    babel-code-frame "^6.22.0"
-    chalk "^2.4.1"
-    chokidar "^2.0.4"
-    micromatch "^3.1.10"
-    minimatch "^3.0.4"
-    semver "^5.6.0"
-    tapable "^1.0.0"
-
 fork-ts-checker-webpack-plugin@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.5.0.tgz#ce1d77190b44d81a761b10b6284a373795e41f0c"
@@ -10116,6 +10346,20 @@ fork-ts-checker-webpack-plugin@1.5.0:
     babel-code-frame "^6.22.0"
     chalk "^2.4.1"
     chokidar "^2.0.4"
+    micromatch "^3.1.10"
+    minimatch "^3.0.4"
+    semver "^5.6.0"
+    tapable "^1.0.0"
+    worker-rpc "^0.1.0"
+
+fork-ts-checker-webpack-plugin@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-3.1.1.tgz#a1642c0d3e65f50c2cc1742e9c0a80f441f86b19"
+  integrity sha512-DuVkPNrM12jR41KM2e+N+styka0EgLkTnXmNcXdgOM37vtGeY+oCBK/Jx0hzSeEU6memFCtWb4htrHPMDfwwUQ==
+  dependencies:
+    babel-code-frame "^6.22.0"
+    chalk "^2.4.1"
+    chokidar "^3.3.0"
     micromatch "^3.1.10"
     minimatch "^3.0.4"
     semver "^5.6.0"
@@ -10369,6 +10613,13 @@ gaze@^1.0.0:
   integrity sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==
   dependencies:
     globule "^1.0.0"
+
+generic-names@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/generic-names/-/generic-names-2.0.1.tgz#f8a378ead2ccaa7a34f0317b05554832ae41b872"
+  integrity sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==
+  dependencies:
+    loader-utils "^1.1.0"
 
 genfun@^5.0.0:
   version "5.0.0"
@@ -10790,7 +11041,7 @@ globby@8.0.2:
     pify "^3.0.0"
     slash "^1.0.0"
 
-globby@^10.0.0:
+globby@^10.0.0, globby@^10.0.1:
   version "10.0.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.2.tgz#277593e745acaa4646c3ab411289ec47a0392543"
   integrity sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==
@@ -11012,14 +11263,6 @@ gulplog@^1.0.0:
   dependencies:
     glogg "^1.0.0"
 
-gzip-size@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.0.0.tgz#a55ecd99222f4c48fd8c01c625ce3b349d0a0e80"
-  integrity sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==
-  dependencies:
-    duplexer "^0.1.1"
-    pify "^3.0.0"
-
 gzip-size@5.1.1, gzip-size@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274"
@@ -11237,11 +11480,6 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-hoist-non-react-statics@^2.5.5:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
 hoist-non-react-statics@^3.1.0:
   version "3.3.2"
@@ -11546,12 +11784,12 @@ iconv-lite@0.4.24, iconv-lite@^0.4.13, iconv-lite@^0.4.24, iconv-lite@^0.4.4, ic
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-icss-replace-symbols@^1.1.0:
+icss-replace-symbols@1.1.0, icss-replace-symbols@^1.0.2, icss-replace-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
   integrity sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=
 
-icss-utils@^4.0.0, icss-utils@^4.1.0, icss-utils@^4.1.1:
+icss-utils@^4.0.0, icss-utils@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-4.1.1.tgz#21170b53789ee27447c2f47dd683081403f9a467"
   integrity sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==
@@ -11783,25 +12021,6 @@ inquirer@6.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-inquirer@6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.1.tgz#9943fc4882161bdb0b0c9276769c75b32dbfcd52"
-  integrity sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==
-  dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.0"
-    cli-cursor "^2.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.0"
-    figures "^2.0.0"
-    lodash "^4.17.10"
-    mute-stream "0.0.7"
-    run-async "^2.2.0"
-    rxjs "^6.1.0"
-    string-width "^2.1.0"
-    strip-ansi "^5.0.0"
-    through "^2.3.6"
-
 inquirer@6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.0.tgz#2303317efc9a4ea7ec2e2df6f86569b734accf42"
@@ -11818,6 +12037,25 @@ inquirer@6.5.0:
     run-async "^2.2.0"
     rxjs "^6.4.0"
     string-width "^2.1.0"
+    strip-ansi "^5.1.0"
+    through "^2.3.6"
+
+inquirer@7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.4.tgz#99af5bde47153abca23f5c7fc30db247f39da703"
+  integrity sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^2.4.2"
+    cli-cursor "^3.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.15"
+    mute-stream "0.0.8"
+    run-async "^2.2.0"
+    rxjs "^6.5.3"
+    string-width "^4.1.0"
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
@@ -12054,6 +12292,11 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
+is-docker@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
+  integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -12215,7 +12458,7 @@ is-object@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
   integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
 
-is-path-cwd@^2.0.0:
+is-path-cwd@^2.0.0, is-path-cwd@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
   integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
@@ -12240,6 +12483,11 @@ is-path-inside@^2.1.0:
   integrity sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==
   dependencies:
     path-is-inside "^1.0.2"
+
+is-path-inside@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
+  integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
 
 is-plain-obj@^1.0.0, is-plain-obj@^1.1, is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -12303,11 +12551,6 @@ is-retry-allowed@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
   integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
-
-is-root@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.0.0.tgz#838d1e82318144e5a6f77819d90207645acc7019"
-  integrity sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg==
 
 is-root@2.1.0:
   version "2.1.0"
@@ -12393,6 +12636,11 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+is-wsl@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
+  integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
 
 isarray@0.0.1:
   version "0.0.1"
@@ -13935,7 +14183,7 @@ leven@^3.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
-levenary@^1.1.0:
+levenary@^1.1.0, levenary@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/levenary/-/levenary-1.1.1.tgz#842a9ee98d2075aa7faeedbe32679e9205f46f77"
   integrity sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==
@@ -14184,6 +14432,15 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
+loader-utils@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
+  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^1.0.1"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -14222,6 +14479,18 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
+lodash._arrayeach@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz#bab156b2a90d3f1bbd5c653403349e5e5933ef9e"
+  integrity sha1-urFWsqkNPxu9XGU0AzSeXlkz754=
+
+lodash._baseeach@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz#cf8706572ca144e8d9d75227c990da982f932af3"
+  integrity sha1-z4cGVyyhROjZ11InyZDamC+TKvM=
+  dependencies:
+    lodash.keys "^3.0.0"
+
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -14230,10 +14499,20 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
+lodash._bindcallback@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
+  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
+
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
+
+lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -14330,6 +14609,16 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
+lodash.foreach@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-3.0.3.tgz#6fd7efb79691aecd67fdeac2761c98e701d6c39a"
+  integrity sha1-b9fvt5aRrs1n/erCdhyY5wHWw5o=
+  dependencies:
+    lodash._arrayeach "^3.0.0"
+    lodash._baseeach "^3.0.0"
+    lodash._bindcallback "^3.0.0"
+    lodash.isarray "^3.0.0"
+
 lodash.foreach@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
@@ -14364,6 +14653,16 @@ lodash.invertby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.invertby/-/lodash.invertby-4.7.0.tgz#cdebb6cd4942aa6b8df2c74be1c5d948682718b0"
   integrity sha1-zeu2zUlCqmuN8sdL4cXZSGgnGLA=
+
+lodash.isarguments@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
+
+lodash.isarray@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+  integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
 
 lodash.isempty@^4.4.0:
   version "4.4.0"
@@ -14404,6 +14703,15 @@ lodash.isundefined@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz#23ef3d9535565203a66cefd5b830f848911afb48"
   integrity sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g=
+
+lodash.keys@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
+  integrity sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=
+  dependencies:
+    lodash._getnative "^3.0.0"
+    lodash.isarguments "^3.0.0"
+    lodash.isarray "^3.0.0"
 
 lodash.keys@^4.2.0:
   version "4.2.0"
@@ -14555,7 +14863,7 @@ lodash@4.17.14:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
-lodash@4.17.15, lodash@=4.17.15, lodash@^4.0.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10:
+lodash@4.17.15, lodash@=4.17.15, lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -15169,19 +15477,20 @@ mini-create-react-context@^0.3.0:
     gud "^1.0.0"
     tiny-warning "^1.0.2"
 
-mini-css-extract-plugin@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz#ac0059b02b9692515a637115b0cc9fed3a35c7b0"
-  integrity sha512-IuaLjruM0vMKhUUT51fQdQzBYTX49dLj8w68ALEAe2A4iYNpIC4eMac67mt3NzycvjOlf07/kYxJDc0RTl1Wqw==
-  dependencies:
-    loader-utils "^1.1.0"
-    schema-utils "^1.0.0"
-    webpack-sources "^1.1.0"
-
 mini-css-extract-plugin@^0.8.0:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.2.tgz#a875e169beb27c88af77dd962771c9eedc3da161"
   integrity sha512-a3Y4of27Wz+mqK3qrcd3VhYz6cU0iW5x3Sgvqzbj+XmlrSizmvu8QQMl5oMYJjgHOC4iyt+w7l4umP+dQeW3bw==
+  dependencies:
+    loader-utils "^1.1.0"
+    normalize-url "1.9.1"
+    schema-utils "^1.0.0"
+    webpack-sources "^1.1.0"
+
+mini-css-extract-plugin@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz#47f2cf07aa165ab35733b1fc97d4c46c0564339e"
+  integrity sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==
   dependencies:
     loader-utils "^1.1.0"
     normalize-url "1.9.1"
@@ -15488,7 +15797,7 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-mute-stream@~0.0.4:
+mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
@@ -15809,10 +16118,17 @@ node-pre-gyp@^0.13.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.29, node-releases@^1.1.3, node-releases@^1.1.46:
+node-releases@^1.1.29, node-releases@^1.1.46:
   version "1.1.47"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.47.tgz#c59ef739a1fd7ecbd9f0b7cf5b7871e8a8b591e4"
   integrity sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==
+  dependencies:
+    semver "^6.3.0"
+
+node-releases@^1.1.47, node-releases@^1.1.49:
+  version "1.1.49"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.49.tgz#67ba5a3fac2319262675ef864ed56798bb33b93e"
+  integrity sha512-xH8t0LS0disN0mtRCh+eByxFPie+msJUBL/lJDBuap53QGiYPa9joh83K4pCZgWJ+2L4b9h88vCVdXQ60NO2bg==
   dependencies:
     semver "^6.3.0"
 
@@ -16331,11 +16647,6 @@ object-path@0.11.4:
   resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
   integrity sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=
 
-object-unfreeze@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/object-unfreeze/-/object-unfreeze-1.1.0.tgz#69628bea1f3c9d29f4eb0ba63b38002d70ea3ce9"
-  integrity sha1-aWKL6h88nSn06wumOzgALXDqPOk=
-
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
@@ -16499,6 +16810,14 @@ open@^6.3.0:
   dependencies:
     is-wsl "^1.1.0"
 
+open@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.0.2.tgz#fb3681f11f157f2361d2392307548ca1792960e8"
+  integrity sha512-70E/pFTPr7nZ9nLDPNTcj3IVqnNvKuP4VsBmoKV9YGTnChe0mlS3C4qM7qKarhZ8rGaHKLfo+vBTHXDp6ZSyLQ==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 opencollective-postinstall@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
@@ -16523,13 +16842,6 @@ openzeppelin-solidity@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/openzeppelin-solidity/-/openzeppelin-solidity-2.4.0.tgz#5f0a7b30571c45493449166e57b947203415349d"
   integrity sha512-533gc5jkspxW5YT0qJo02Za5q1LHwXK9CJCc48jNj/22ncNM/3M/3JfWLqfpB90uqLwOKOovpl0JfaMQTR+gXQ==
-
-opn@5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-5.4.0.tgz#cb545e7aab78562beb11aa3bfabc7042e1761035"
-  integrity sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==
-  dependencies:
-    is-wsl "^1.1.0"
 
 opn@^5.1.0, opn@^5.5.0:
   version "5.5.0"
@@ -17288,6 +17600,13 @@ pkg-up@2.0.0, pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pkg-up@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -17504,6 +17823,20 @@ postcss-minify-selectors@^4.0.2:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
+postcss-modules-extract-imports@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz#b614c9720be6816eaee35fb3a5faa1dba6a05ddb"
+  integrity sha1-thTJcgvmgW6u41+zpfqh26agXds=
+  dependencies:
+    postcss "^6.0.1"
+
+postcss-modules-extract-imports@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz#dc87e34148ec7eab5f791f7cd5849833375b741a"
+  integrity sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==
+  dependencies:
+    postcss "^6.0.1"
+
 postcss-modules-extract-imports@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz#818719a1ae1da325f9832446b01136eeb493cd7e"
@@ -17511,14 +17844,13 @@ postcss-modules-extract-imports@^2.0.0:
   dependencies:
     postcss "^7.0.5"
 
-postcss-modules-local-by-default@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.6.tgz#dd9953f6dd476b5fd1ef2d8830c8929760b56e63"
-  integrity sha512-oLUV5YNkeIBa0yQl7EYnxMgy4N6noxmiwZStaEJUSe2xPMcdNc8WmBQuQCx18H5psYbVxz8zoHk0RAAYZXP9gA==
+postcss-modules-local-by-default@1.2.0, postcss-modules-local-by-default@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz#f7d80c398c5a393fa7964466bd19500a7d61c069"
+  integrity sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=
   dependencies:
-    postcss "^7.0.6"
-    postcss-selector-parser "^6.0.0"
-    postcss-value-parser "^3.3.1"
+    css-selector-tokenizer "^0.7.0"
+    postcss "^6.0.1"
 
 postcss-modules-local-by-default@^3.0.2:
   version "3.0.2"
@@ -17530,7 +17862,24 @@ postcss-modules-local-by-default@^3.0.2:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.0.0"
 
-postcss-modules-scope@^2.1.0, postcss-modules-scope@^2.1.1:
+postcss-modules-parser@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-modules-parser/-/postcss-modules-parser-1.1.1.tgz#95f71ad7916f0f39207bb81c401336c8d245738c"
+  integrity sha1-lfca15FvDzkge7gcQBM2yNJFc4w=
+  dependencies:
+    icss-replace-symbols "^1.0.2"
+    lodash.foreach "^3.0.3"
+    postcss "^5.0.10"
+
+postcss-modules-scope@1.1.0, postcss-modules-scope@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz#d6ea64994c79f97b62a72b426fbe6056a194bb90"
+  integrity sha1-1upkmUx5+XtipytCb75gVqGUu5A=
+  dependencies:
+    css-selector-tokenizer "^0.7.0"
+    postcss "^6.0.1"
+
+postcss-modules-scope@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-2.1.1.tgz#33d4fc946602eb5e9355c4165d68a10727689dba"
   integrity sha512-OXRUPecnHCg8b9xWvldG/jUpRIGPNRka0r4D4j0ESUU2/5IOnpsjfPPmDprM3Ih8CgZ8FXjWqaniK5v4rWt3oQ==
@@ -17538,13 +17887,13 @@ postcss-modules-scope@^2.1.0, postcss-modules-scope@^2.1.1:
     postcss "^7.0.6"
     postcss-selector-parser "^6.0.0"
 
-postcss-modules-values@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz#479b46dc0c5ca3dc7fa5270851836b9ec7152f64"
-  integrity sha512-Ki7JZa7ff1N3EIMlPnGTZfUMe69FFwiQPnVSXC9mnn3jozCRBYIxiZd44yJOV2AmabOo4qFf8s0dC/+lweG7+w==
+postcss-modules-values@1.3.0, postcss-modules-values@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz#ecffa9d7e192518389f42ad0e83f72aec456ea20"
+  integrity sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=
   dependencies:
     icss-replace-symbols "^1.1.0"
-    postcss "^7.0.6"
+    postcss "^6.0.1"
 
 postcss-modules-values@^3.0.0:
   version "3.0.0"
@@ -17553,6 +17902,17 @@ postcss-modules-values@^3.0.0:
   dependencies:
     icss-utils "^4.0.0"
     postcss "^7.0.6"
+
+postcss-modules@^1.3.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules/-/postcss-modules-1.5.0.tgz#08da6ce43fcfadbc685a021fe6ed30ef929f0bcc"
+  integrity sha512-KiAihzcV0TxTTNA5OXreyIXctuHOfR50WIhqBpc8pe0Q5dcs/Uap9EVlifOI9am7zGGdGOJQ6B1MPYKo2UxgOg==
+  dependencies:
+    css-modules-loader-core "^1.1.0"
+    generic-names "^2.0.1"
+    lodash.camelcase "^4.3.0"
+    postcss "^7.0.1"
+    string-hash "^1.1.1"
 
 postcss-normalize-charset@^4.0.1:
   version "4.0.1"
@@ -17717,7 +18077,7 @@ postcss-unique-selectors@^4.0.1:
     postcss "^7.0.0"
     uniqs "^2.0.0"
 
-postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.0, postcss-value-parser@^3.3.1:
+postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
@@ -17726,6 +18086,15 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz#482282c09a42706d1fc9a069b73f44ec08391dc9"
   integrity sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==
+
+postcss@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.1.tgz#000dbd1f8eef217aa368b9a212c5fc40b2a8f3f2"
+  integrity sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=
+  dependencies:
+    chalk "^1.1.3"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
 
 postcss@7.0.21:
   version "7.0.21"
@@ -17736,7 +18105,7 @@ postcss@7.0.21:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^5.2.17:
+postcss@^5.0.10, postcss@^5.2.17:
   version "5.2.18"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
   integrity sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==
@@ -17746,10 +18115,28 @@ postcss@^5.2.17:
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
+postcss@^6.0.1:
+  version "6.0.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
+  integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
+
 postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.23, postcss@^7.0.26, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.26"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.26.tgz#5ed615cfcab35ba9bbb82414a4fa88ea10429587"
   integrity sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
+postcss@^7.0.2:
+  version "7.0.27"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.27.tgz#cc67cdc6b0daa375105b7c424a85567345fc54d9"
+  integrity sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -18312,15 +18699,6 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-css-modules@^4.7.9:
-  version "4.7.11"
-  resolved "https://registry.yarnpkg.com/react-css-modules/-/react-css-modules-4.7.11.tgz#e9bc7ac6e3dd7e71c8e46e9d22c1d0abb2110682"
-  integrity sha512-ke/zMcBKQyq7x4I5CREzeA/cZSg7MW/Kx23L1OICd+PXKNq++fMdAJDeDLFYkDY28TwuAHpwsKxDYEVjpEMkmQ==
-  dependencies:
-    hoist-non-react-statics "^2.5.5"
-    lodash "^4.16.6"
-    object-unfreeze "^1.1.0"
-
 react-custom-scrollbars@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/react-custom-scrollbars/-/react-custom-scrollbars-4.2.1.tgz#830fd9502927e97e8a78c2086813899b2a8b66db"
@@ -18330,35 +18708,34 @@ react-custom-scrollbars@^4.2.1:
     prop-types "^15.5.10"
     raf "^3.1.0"
 
-react-dev-utils@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-8.0.0.tgz#7c5b227a45a32ea8ff7fbc318f336cf9e2c6e34c"
-  integrity sha512-TK8cj7eghvxfe7bfBluLGpI/upo4EXC+G74hYmPucAG8C2XcbT+vKnlWPwLnABb75Zk+mR6D556Da+yvDjljrw==
+react-dev-utils@^10.1.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-10.2.0.tgz#b11cc48aa2be2502fb3c27a50d1dfa95cfa9dfe0"
+  integrity sha512-MwrvQW2TFjLblhqpDNeqCXHBkz3G5vc7k4wntgutAJZX4ia3o07eGKo6uYGhUOeJ0hfOxcpJFNFk7+4XCc1S8g==
   dependencies:
-    "@babel/code-frame" "7.0.0"
-    address "1.0.3"
-    browserslist "4.4.1"
+    "@babel/code-frame" "7.8.3"
+    address "1.1.2"
+    browserslist "4.8.6"
     chalk "2.4.2"
-    cross-spawn "6.0.5"
+    cross-spawn "7.0.1"
     detect-port-alt "1.1.6"
-    escape-string-regexp "1.0.5"
-    filesize "3.6.1"
-    find-up "3.0.0"
-    fork-ts-checker-webpack-plugin "1.0.0-alpha.6"
+    escape-string-regexp "2.0.0"
+    filesize "6.0.1"
+    find-up "4.1.0"
+    fork-ts-checker-webpack-plugin "3.1.1"
     global-modules "2.0.0"
     globby "8.0.2"
-    gzip-size "5.0.0"
+    gzip-size "5.1.1"
     immer "1.10.0"
-    inquirer "6.2.1"
-    is-root "2.0.0"
+    inquirer "7.0.4"
+    is-root "2.1.0"
     loader-utils "1.2.3"
-    opn "5.4.0"
-    pkg-up "2.0.0"
-    react-error-overlay "^5.1.4"
+    open "^7.0.2"
+    pkg-up "3.1.0"
+    react-error-overlay "^6.0.6"
     recursive-readdir "2.2.2"
-    shell-quote "1.6.1"
-    sockjs-client "1.3.0"
-    strip-ansi "5.0.0"
+    shell-quote "1.7.2"
+    strip-ansi "6.0.0"
     text-table "0.2.0"
 
 react-dev-utils@^9.0.3:
@@ -18402,15 +18779,15 @@ react-dom@^16.8.4, react-dom@^16.8.6:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
-react-error-overlay@^5.1.4:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
-  integrity sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==
-
 react-error-overlay@^6.0.3:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.4.tgz#0d165d6d27488e660bc08e57bdabaad741366f7a"
   integrity sha512-ueZzLmHltszTshDMwyfELDq8zOA803wQ1ZuzCccXa1m57k1PxSHfflPD5W9YIiTXLs0JTLzoj6o1LuM5N6zzNA==
+
+react-error-overlay@^6.0.6:
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.6.tgz#ac4d9dc4c1b5c536c2c312bf66aa2b09bfa384e2"
+  integrity sha512-Yzpno3enVzSrSCnnljmr4b/2KUQSMZaPuqmS26t9k4nW7uwJk6STWmH9heNjPuvqUTO3jOSPkHoKgO4+Dw7uIw==
 
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.12.0"
@@ -18794,6 +19171,15 @@ regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
+regexpu-core@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-1.0.0.tgz#86a763f58ee4d7c2f6b102e4764050de7ed90c6b"
+  integrity sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=
+  dependencies:
+    regenerate "^1.2.1"
+    regjsgen "^0.2.0"
+    regjsparser "^0.1.4"
 
 regexpu-core@^2.0.0:
   version "2.0.0"
@@ -19223,6 +19609,13 @@ rimraf@2.6.3, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -19821,16 +20214,6 @@ shell-exec@^1.0.2:
   resolved "https://registry.yarnpkg.com/shell-exec/-/shell-exec-1.0.2.tgz#2e9361b0fde1d73f476c4b6671fa17785f696756"
   integrity sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==
 
-shell-quote@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
-  integrity sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=
-  dependencies:
-    array-filter "~0.0.0"
-    array-map "~0.0.0"
-    array-reduce "~0.0.0"
-    jsonify "~0.0.0"
-
 shell-quote@1.7.2, shell-quote@^1.6.1:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
@@ -20010,18 +20393,6 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
-
-sockjs-client@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.3.0.tgz#12fc9d6cb663da5739d3dc5fb6e8687da95cb177"
-  integrity sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==
-  dependencies:
-    debug "^3.2.5"
-    eventsource "^1.0.7"
-    faye-websocket "~0.11.1"
-    inherits "^2.0.3"
-    json3 "^3.3.2"
-    url-parse "^1.4.3"
 
 sockjs-client@1.4.0:
   version "1.4.0"
@@ -20498,6 +20869,11 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
+string-hash@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
+  integrity sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=
+
 string-kit@^0.11.6:
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/string-kit/-/string-kit-0.11.6.tgz#daee376e8e3b036f6c359912f1f3eb064304d392"
@@ -20603,19 +20979,19 @@ stringify-package@^1.0.0, stringify-package@^1.0.1:
   resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.1.tgz#e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
 
-strip-ansi@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.0.0.tgz#f78f68b5d0866c20b2c9b8c61b5298508dc8756f"
-  integrity sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==
-  dependencies:
-    ansi-regex "^4.0.0"
-
 strip-ansi@5.2.0, strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@6.0.0, strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -20630,13 +21006,6 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
-  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
-  dependencies:
-    ansi-regex "^5.0.0"
 
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
@@ -20783,14 +21152,14 @@ supports-color@^3.1.0, supports-color@^3.1.2, supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.0.0, supports-color@^5.2.0, supports-color@^5.3.0, supports-color@^5.5.0:
+supports-color@^5.0.0, supports-color@^5.2.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0:
+supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==


### PR DESCRIPTION
## Summary
This PR adds support to the `AccountRegistry.sol` for the DAI `permit()` function. 

The new DAI `permit()` function allows ERC20 spending approval to be granted via an offchain signature, rather than the sending of a transaction. 

Background on the `DAI.permit()` method: https://docs.makerdao.com/smart-contract-modules/dai-module/dai-detailed-documentation 

## Description
A new `AccountRegistry` behaviour contract, `Behaviour20200220.sol` has been added. This defines two methods with unique function signatures:

1. `deposit()` - convert DAI into zkDAI
2. `permit()`- call `DAI.permit()`

Given that `permit()` is currently not part of the ERC20 standard, and is a DAI specific method, it is importantly that the `AccountRegistry` supports both legacy approval flows and the new `permit()` approval flow. 

To this end, both the legacy `Behaviour20200106.deposit()` method and the new `Behaviour20200220.deposit()` method are available - they have different signatures as `Behaviour20200220.deposit()` takes two additional parameters `signature` and `nonce`. 

`signature` is an EIP712 signature that is passed to the `DAI.permit()` method. It is used to approve the `proxyContract` to spend DAI on behalf of the user, rather than having to send a `dai.approve()` transaction.  

`nonce` is a record of the number of `permit()` calls have been made and is used for signature replay protection in the DAI contract. 

### `Behaviour20200220.permit()`
This method has been given the visibility modifier of `public` so that users are able to directly call `permit()` and so revoke approval at a later date if they wish/need to. 