### PR TITLE
Fix account registry behaviour migrations

### DIFF
--- a/packages/protocol/migrations/16_deploy_accountRegistryBehaviour20200207.js
+++ b/packages/protocol/migrations/16_deploy_accountRegistryBehaviour20200207.js
@@ -1,6 +1,5 @@
 /* global artifacts */
 const dotenv = require('dotenv');
-const { getContractAddressesForNetwork, NetworkId: networkIds } = require('@aztec/contract-addresses');
 
 dotenv.config();
 const AccountRegistryBehaviour20200207 = artifacts.require('./AccountRegistry/epochs/20200207/Behaviour20200207');
@@ -15,9 +14,7 @@ module.exports = (deployer, network) => {
         if (isLocal) {
             managerContract = await AccountRegistryManager.deployed();
         } else {
-            const formattedNetwork = network[0].toUpperCase() + network.slice(1);
-            const { AccountRegistryManager: managerAddress } = getContractAddressesForNetwork(networkIds[formattedNetwork]);
-            managerContract = await AccountRegistryManager.at(managerAddress);
+            managerContract = await AccountRegistryManager.at(AccountRegistryManager.address);
         }
 
         // Perform the upgrade

--- a/packages/protocol/migrations/17_deploy_accountRegistryBehaviour20200220.js
+++ b/packages/protocol/migrations/17_deploy_accountRegistryBehaviour20200220.js
@@ -1,6 +1,5 @@
 /* global artifacts */
 const dotenv = require('dotenv');
-const { getContractAddressesForNetwork, NetworkId: networkIds } = require('@aztec/contract-addresses');
 
 dotenv.config();
 const AccountRegistryBehaviour20200220 = artifacts.require('./AccountRegistry/epochs/20200207/Behaviour20200220');
@@ -15,9 +14,7 @@ module.exports = (deployer, network) => {
         if (isLocal) {
             managerContract = await AccountRegistryManager.deployed();
         } else {
-            const formattedNetwork = network[0].toUpperCase() + network.slice(1);
-            const { AccountRegistryManager: managerAddress } = getContractAddressesForNetwork(networkIds[formattedNetwork]);
-            managerContract = await AccountRegistryManager.at(managerAddress);
+            managerContract = await AccountRegistryManager.at(AccountRegistryManager.address);
         }
 
         // Perform the upgrade


### PR DESCRIPTION
## Summary
This PR fixes the `AccountRegistry` behaviour migration scripts - specifically migrations `16` and `17`. 

The scripts were upgrading a previously deployed version of the account registry, rather than the latest version. 
<!--- Summarise your changes -->

## Description
When the upgrade was performed in these migrations, instantiating the manager contract by doing:

```
const { AccountRegistryManager: managerAddress } = getContractAddressesForNetwork(networkIds[formattedNetwork]);
managerContract = await AccountRegistryManager.at(managerAddress);
```

This meant the newest registry wasn't being upgraded (hadn't been committed to `contractAddresses` yet). It was also preventing upgrades as the `latestEpoch` was higher (due to the last set of upgrades) than the `currentEpoch` for lower level upgrades. 

Now takes the `managerAddress` from the artifact. 
