### PR TITLE
Fix migration for `Behaviour20200220`

### DIFF
--- a/packages/protocol/migrations/17_deploy_accountRegistryBehaviour20200220.js
+++ b/packages/protocol/migrations/17_deploy_accountRegistryBehaviour20200220.js
@@ -2,7 +2,7 @@
 const dotenv = require('dotenv');
 
 dotenv.config();
-const AccountRegistryBehaviour20200220 = artifacts.require('./AccountRegistry/epochs/20200207/Behaviour20200220');
+const AccountRegistryBehaviour20200220 = artifacts.require('./AccountRegistry/epochs/20200220/Behaviour20200220');
 const AccountRegistryManager = artifacts.require('./AccountRegistry/AccountRegistryManager');
 
 module.exports = (deployer, network) => {


### PR DESCRIPTION
## Summary
This PR fixes a small bug in the `17_deploy_accountRegistryBehaviour20200220.js` deployment script, where the incorrect behaviour contract version was being imported and migrated. 
