### PR TITLE
Update registry behaviour interface

### DIFF
--- a/packages/protocol/contracts/AccountRegistry/interfaces/IAccountRegistryBehaviour.sol
+++ b/packages/protocol/contracts/AccountRegistry/interfaces/IAccountRegistryBehaviour.sol
@@ -39,15 +39,6 @@ contract IAccountRegistryBehaviour {
     function initialize(address _aceAddress, address _trustedGSNSignerAddress) external;
 
     function confidentialTransferFrom(
-        address _registryOwner,
-        bytes calldata _proofData,
-        bytes32[] calldata _noteHashes,
-        address _spender,
-        bool[] calldata _spenderApprovals,
-        bytes calldata _batchSignature
-    ) external;
-
-    function confidentialTransferFrom(
         uint24 _proofId,
         address _registryOwner,
         bytes calldata _proofData,


### PR DESCRIPTION
## Summary
This PR updates the `IAccountRegistryBehaviourInterface.sol`, by removing an old `confidentialTransferFrom()` method 