### PR TITLE
convert MetaDataUtils.sol to a library

### DIFF
--- a/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
@@ -32,7 +32,6 @@ import "../../libs/ProofUtils.sol";
 **/
 contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712 {
     using NoteUtils for bytes;
-    using MetaDataUtils for bytes;
     using SafeMath for uint256;
     using ProofUtils for uint24;
 
@@ -474,7 +473,7 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712 {
             address[] memory extractedAddresses = new address[](uint256(numAddresses));
 
             for (uint256 i = 0; i < uint256(numAddresses); i += 1) {
-                address extractedAddress = metaData.extractAddress(i);
+                address extractedAddress = MetaDataUtils.extractAddress(metaData, i);
                 bytes32 addressID = keccak256(abi.encodePacked(extractedAddress, noteHash));
                 noteAccess[addressID] = block.timestamp;
             }

--- a/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
@@ -30,8 +30,9 @@ import "../../libs/ProofUtils.sol";
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 **/
-contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
+contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712 {
     using NoteUtils for bytes;
+    using MetaDataUtils for bytes;
     using SafeMath for uint256;
     using ProofUtils for uint24;
 
@@ -473,7 +474,7 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
             address[] memory extractedAddresses = new address[](uint256(numAddresses));
 
             for (uint256 i = 0; i < uint256(numAddresses); i += 1) {
-                address extractedAddress = extractAddress(metaData, i);
+                address extractedAddress = metaData.extractAddress(i);
                 bytes32 addressID = keccak256(abi.encodePacked(extractedAddress, noteHash));
                 noteAccess[addressID] = block.timestamp;
             }

--- a/packages/protocol/contracts/interfaces/IZkAsset.sol
+++ b/packages/protocol/contracts/interfaces/IZkAsset.sol
@@ -100,15 +100,6 @@ interface IZkAsset {
     */
     function confidentialTransfer(uint24 _proofId, bytes calldata _proofData, bytes calldata _signatures) external;
 
-
-    /**
-    * @dev Extract a single approved address from the metaData
-    * @param metaData - metaData containing addresses according to the schema defined in x
-    * @param addressPos - indexer for the desired address, the one to be extracted
-    * @return desiredAddress - extracted address specified by the inputs to this function
-    */
-    function extractAddress(bytes calldata metaData, uint256 addressPos) external returns (address desiredAddress);
-
     /**
     * @dev Update the metadata of a note that already exists in storage.
     * @param noteHash - hash of a note, used as a unique identifier for the note

--- a/packages/protocol/contracts/interfaces/IZkAssetAdjustable.sol
+++ b/packages/protocol/contracts/interfaces/IZkAssetAdjustable.sol
@@ -123,14 +123,6 @@ interface IZkAssetAdjustable {
     */
     function confidentialTransfer(uint24 _proofId, bytes calldata _proofData, bytes calldata _signatures) external;
 
-    /**
-    * @dev Extract a single approved address from the metaData
-    * @param metaData - metaData containing addresses according to the schema defined in x
-    * @param addressPos - indexer for the desired address, the one to be extracted
-    * @return desiredAddress - extracted address specified by the inputs to this function
-    */
-    function extractAddress(bytes calldata metaData, uint256 addressPos) external returns (address desiredAddress);
-
     function isOwner() external view returns (bool);
 
     function owner() external returns (address);

--- a/packages/protocol/contracts/interfaces/IZkAssetBurnable.sol
+++ b/packages/protocol/contracts/interfaces/IZkAssetBurnable.sol
@@ -120,14 +120,6 @@ interface IZkAssetBurnable {
     */
     function confidentialTransfer(uint24 _proofId, bytes calldata _proofData, bytes calldata _signatures) external;
 
-    /**
-    * @dev Extract a single approved address from the metaData
-    * @param metaData - metaData containing addresses according to the schema defined in x
-    * @param addressPos - indexer for the desired address, the one to be extracted
-    * @return desiredAddress - extracted address specified by the inputs to this function
-    */
-    function extractAddress(bytes calldata metaData, uint256 addressPos) external returns (address desiredAddress);
-
     function isOwner() external view returns (bool);
 
     function owner() external returns (address);

--- a/packages/protocol/contracts/interfaces/IZkAssetMintable.sol
+++ b/packages/protocol/contracts/interfaces/IZkAssetMintable.sol
@@ -111,14 +111,6 @@ interface IZkAssetMintable {
     */
     function confidentialTransfer(uint24 _proofId, bytes calldata _proofData, bytes calldata _signatures) external;
 
-    /**
-    * @dev Extract a single approved address from the metaData
-    * @param metaData - metaData containing addresses according to the schema defined in x
-    * @param addressPos - indexer for the desired address, the one to be extracted
-    * @return desiredAddress - extracted address specified by the inputs to this function
-    */
-    function extractAddress(bytes calldata metaData, uint256 addressPos) external returns (address desiredAddress);
-
     function isOwner() external view returns (bool);
 
     function owner() external returns (address);

--- a/packages/protocol/contracts/interfaces/IZkAssetOwnable.sol
+++ b/packages/protocol/contracts/interfaces/IZkAssetOwnable.sol
@@ -98,14 +98,6 @@ interface IZkAssetOwnable {
     */
     function confidentialTransfer(uint24 _proofId, bytes calldata _proofData, bytes calldata _signatures) external;
 
-    /**
-    * @dev Extract a single approved address from the metaData
-    * @param metaData - metaData containing addresses according to the schema defined in x
-    * @param addressPos - indexer for the desired address, the one to be extracted
-    * @return desiredAddress - extracted address specified by the inputs to this function
-    */
-    function extractAddress(bytes calldata metaData, uint256 addressPos) external returns (address desiredAddress);
-
     function isOwner() external view returns (bool);
 
     function owner() external returns (address);

--- a/packages/protocol/contracts/libs/MetaDataUtils.sol
+++ b/packages/protocol/contracts/libs/MetaDataUtils.sol
@@ -19,14 +19,14 @@ pragma solidity >=0.5.0 <= 0.6.0;
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-contract MetaDataUtils {
+library MetaDataUtils {
     /**
     * @dev Extract a single approved address from the metaData
     * @param metaData - metaData containing addresses according to the schema defined in x
     * @param addressPos - indexer for the desired address, the one to be extracted
     * @return desiredAddress - extracted address specified by the inputs to this function
     */
-    function extractAddress(bytes memory metaData, uint256 addressPos) public returns (address desiredAddress) {
+    function extractAddress(bytes memory metaData, uint256 addressPos) pure internal returns (address desiredAddress) {
         /**
         * Memory map of metaData. This is the ABI encoding of metaData, supplied by the client
         * The first word of any dynamic bytes array within this map, is the number of discrete elements in that 

--- a/packages/protocol/contracts/test/ERC1724/ZkAssetTest.sol
+++ b/packages/protocol/contracts/test/ERC1724/ZkAssetTest.sol
@@ -1,7 +1,6 @@
 pragma solidity >=0.5.0 <0.6.0;
 
 import "../../ERC1724/ZkAsset.sol";
-import "../../libs/MetaDataUtils.sol";
 
 /**
  * @title ZkAssetBaseTest

--- a/packages/protocol/contracts/test/libs/MetaDataUtilsTest.sol
+++ b/packages/protocol/contracts/test/libs/MetaDataUtilsTest.sol
@@ -1,0 +1,36 @@
+pragma solidity >= 0.5.0 <0.6.0;
+
+import "../../libs/MetaDataUtils.sol";
+
+/**
+ * @title MetaDataUtilsTest
+ * @author AZTEC
+ * @dev Library of MetaData manipulation operations
+ * 
+ * Copyright 2020 Spilsbury Holdings Ltd 
+ *
+ * Licensed under the GNU Lesser General Public Licence, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+
+contract MetaDataUtilsTest {
+    using MetaDataUtils for bytes;
+    
+    /**
+    * @dev Extract a single approved address from the metaData
+    * @param metaData - metaData containing addresses according to the schema defined in x
+    * @param addressPos - indexer for the desired address, the one to be extracted
+    * @return desiredAddress - extracted address specified by the inputs to this function
+    */
+    function extractAddress(bytes memory metaData, uint256 addressPos) public pure returns (address desiredAddress) {
+      return metaData.extractAddress(addressPos);
+    }
+}

--- a/packages/protocol/test/libs/MetaDataUtils.js
+++ b/packages/protocol/test/libs/MetaDataUtils.js
@@ -4,7 +4,7 @@ const { toChecksumAddress } = require('web3-utils');
 
 const { customMetaData } = require('../helpers/ERC1724');
 
-const MetaDataUtils = artifacts.require('./MetaDataUtils');
+const MetaDataUtils = artifacts.require('./MetaDataUtilsTest');
 
 contract('MetaDataUtils', async () => {
     let metaDataUtils;
@@ -16,7 +16,7 @@ contract('MetaDataUtils', async () => {
     it('should extract a correct address', async () => {
         const address = customMetaData.addresses[0];
         const addressToExtract = 0;
-        const extractedAddress = await metaDataUtils.extractAddress.call(customMetaData.dataWithNewEphemeral, addressToExtract);
+        const extractedAddress = await metaDataUtils.extractAddress(customMetaData.dataWithNewEphemeral, addressToExtract);
         expect(toChecksumAddress(extractedAddress.slice(2))).to.equal(toChecksumAddress(address));
     });
 });


### PR DESCRIPTION
## Summary

I've switched `MetaDataUtils` from a contract to a library

## Description

Does what it says on the tin. `MetaDataUtils` is now a library so that `extractAddress` can 
be attached to `bytes` type objects.

I've also removed `extractAddress` from `IZkAsset`, etc. as it seemed to just be there because it was necessary from inheritance rather than through conscious choice. I had a quick check and couldn't find any instances of that function being called. I can re-add it if necessary though.

## Testing instructions

I've updated the automated tests to handle `MetaDataUtils` being a library. 

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (`MetaDataUtils` can now be loaded as a library)

* Breaking change (`extractAddress` is no longer callable on `IZkAsset`)



## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
