### PR TITLE
remove unused variable extractedAddresses

### DIFF
--- a/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
+++ b/packages/protocol/contracts/ERC1724/base/ZkAssetBase.sol
@@ -470,8 +470,6 @@ contract ZkAssetBase is IZkAsset, IAZTEC, LibEIP712, MetaDataUtils {
 
         // if customData has been set, approve the relevant addresses
         if (uint256(metaDataLength) > 0x61) {
-            address[] memory extractedAddresses = new address[](uint256(numAddresses));
-
             for (uint256 i = 0; i < uint256(numAddresses); i += 1) {
                 address extractedAddress = extractAddress(metaData, i);
                 bytes32 addressID = keccak256(abi.encodePacked(extractedAddress, noteHash));


### PR DESCRIPTION
## Summary

I've removed an unused variable from `ZkAssetBase.sol` to silence a compiler warning.

## Testing instructions

N/A

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue) 
