### PR TITLE
Add custom documentation images to `public` build folder

### DIFF
--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -7,9 +7,10 @@
   },
   "description": "AZTEC Protocol documentation based on React Styleguidist",
   "scripts": {
-    "build": "truffle compile --all && styleguidist build && yarn copy",
+    "build": "truffle compile --all && styleguidist build && yarn copyApis && yarn copyImages",
     "clean": "shx rm -rf ./build  ./dist ./public || true",
-    "copy": "find ../extension/src/client/apis -iregex '.(ZkNote|Account|ZkAsset).' -exec cp {} ./public/apis \\;",
+    "copyApis": "find ../extension/src/client/apis -iregex '.(ZkNote|Account|ZkAsset).' -exec cp {} ./public/apis \\;",
+    "copyImages": "cp -r ./images ./public",
     "generateStyles": "guacamole generateStyles",
     "lint": "eslint --ignore-path .eslintignore .",
     "start": "yarn styleguide",

--- a/packages/documentation/styleguide/categories/Introduction/joinSplitProof.md
+++ b/packages/documentation/styleguide/categories/Introduction/joinSplitProof.md
@@ -7,7 +7,7 @@ In a `JoinSplit` proof particular notes are provided as inputs, and certain note
 Consider the below example as to how value can be transferred using a JoinSplit proof:
 
 &nbsp
-<img src="../../images/joinSplitImage.png" width="75%">
+<img src="../../../images/joinSplitImage.png" width="50%">
 &nbsp
 
 Alice wishes to confidentially transfer Bob 75 zkDAI. She starts off with 2 notes whose value sum to 100 zkDAI, whilst Bob starts off with no notes and no zkDAI.

--- a/packages/documentation/styleguide/categories/Introduction/standardFlow.md
+++ b/packages/documentation/styleguide/categories/Introduction/standardFlow.md
@@ -32,4 +32,4 @@ The below diagram gives an overview of how the key smart contract infrastructure
 &nbsp
 &nbsp
 
-<img src="../../images/architectureOverview.png" width="75%">
+<img src="../../../images/architectureOverview.png" width="50%">

--- a/packages/documentation/styleguide/categories/Introduction/utxoModel.md
+++ b/packages/documentation/styleguide/categories/Introduction/utxoModel.md
@@ -3,4 +3,4 @@ AZTEC utilises a UTXO model like that of Bitcoin, where the UTXOs are called `no
 &nbsp
 &nbsp
 
-<img src="../../images/utxoModel.png" width="50%">
+<img src="../../../images/utxoModel.png" width="50%">


### PR DESCRIPTION
## Summary
This PR copies the local `documentation` `images` folder over to the `public` folder on build. The `public` folder is the source from which files are served for the documentation website.

This fixes an issue where some images were not rendering. 


