### PR TITLE
Fix sdk send api

### DIFF
--- a/packages/extension/src/client/services/MetaMaskService/index.js
+++ b/packages/extension/src/client/services/MetaMaskService/index.js
@@ -9,12 +9,12 @@ import signProof from './signProof';
 const getSignProofSignatureResponse = (address, signature) => {
     if (address === '0x7dd4e19395c47753370a7e20b3788546958b2ea6') {
         return {
-            signature1: signature,
+            signature,
             signature2: signer.makeReplaySignature(signature),
         };
     }
     return {
-        signature1: signature,
+        signature,
     };
 };
 

--- a/packages/extension/src/config/contracts/development.js
+++ b/packages/extension/src/config/contracts/development.js
@@ -1,4 +1,4 @@
-import AccountRegistry from '~contracts/Behaviour20200220.json';
+import AccountRegistry from '~contracts/Behaviour20200305.json';
 import AccountRegistryManager from '~contracts/IAccountRegistryManager.json';
 import ACE from '~contracts/ACE.json';
 import IERC20 from '~contracts/IERC20Mintable.json';

--- a/packages/extension/src/config/contracts/production.js
+++ b/packages/extension/src/config/contracts/production.js
@@ -1,4 +1,4 @@
-import AccountRegistry from '~contracts/Behaviour20200220.json';
+import AccountRegistry from '~contracts/Behaviour20200305.json';
 import AccountRegistryManager from '~contracts/IAccountRegistryManager.json';
 import ACE from '~contracts/IACE.json';
 import IERC20 from '~contracts/IERC20Mintable.json';

--- a/packages/extension/src/ui/apis/asset/confidentialTransferFrom.js
+++ b/packages/extension/src/ui/apis/asset/confidentialTransferFrom.js
@@ -11,7 +11,7 @@ export default async function confidentialTransferFrom({
     assetAddress,
     proof,
     signature1 = '0x',
-    signature2 = '',
+    signature2 = '0x',
     spender,
     isGSNAvailable,
 }) {

--- a/packages/extension/src/ui/apis/asset/confidentialTransferFrom.js
+++ b/packages/extension/src/ui/apis/asset/confidentialTransferFrom.js
@@ -10,7 +10,7 @@ const {
 export default async function confidentialTransferFrom({
     assetAddress,
     proof,
-    signature1 = '0x',
+    signature = '0x',
     signature2 = '0x',
     spender,
     isGSNAvailable,
@@ -24,7 +24,7 @@ export default async function confidentialTransferFrom({
             assetAddress,
             proofData,
             spender,
-            signature1,
+            signature,
             signature2,
         ],
     };

--- a/packages/extension/src/ui/apis/note/signProof.js
+++ b/packages/extension/src/ui/apis/note/signProof.js
@@ -7,6 +7,7 @@ export default async function signProof({
 }) {
     const {
         signature,
+        signature2,
         error,
     } = await ConnectionService.post({
         action: 'metamask.eip712.signProof',
@@ -29,5 +30,6 @@ export default async function signProof({
         spender: sender,
         approval: true,
         signature,
+        signature2,
     };
 }


### PR DESCRIPTION
## Summary

This PR fixes the issue that calling `zkAsset.send` will fail for various reasons.

## Description

1. Wrong contract artifact for account registry
The new `confidentialTransferFrom` has 6 parameters while the old one only has 5. Updating the contract artifacts from `Behaviour20200220` to `Behaviour20200305` in `config/contracts/development` and `config/contracts/production` fixes this.

2. Invalid bytes value
The 6th parameter in `confidentialTransferFrom` was assigned an empty string as default value. Should be `0x`.

3. Wrong return data from MetaMaskService
The old `metamask.eip712.signProof` api in MetaMaskService returned `{ signature }`. It was changed to `{ signature1, signature2 }`. But the function in ui that calls this api was still catching data as `{ signature }`. So both signature1, signature2 were empty at the time we called `confidentialTransferFrom`, causing it to throw an error "sender does not have approval to spend input note".

## Types of changes

Bug fix (non-breaking change which fixes an issue)
