### PR TITLE
Initialize aztec properly

### DIFF
--- a/packages/extension/src/index.js
+++ b/packages/extension/src/index.js
@@ -1,6 +1,6 @@
 import Aztec from '~/client/Aztec';
 
-document.addEventListener('DOMContentLoaded', async () => {
+const initializeAZTEC = async () => {
     const aztec = new Aztec();
     await aztec.generateInitialApis();
     delete aztec.generateInitialApis;
@@ -11,4 +11,17 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (typeof window.aztecCallback === 'function') {
         window.aztecCallback();
     }
-});
+};
+
+const readyStates = [
+    'complete',
+    'interactive',
+];
+
+if (readyStates.indexOf(document.readyState) >= 0) {
+    initializeAZTEC();
+} else {
+    document.addEventListener('DOMContentLoaded', () => {
+        initializeAZTEC();
+    });
+}


### PR DESCRIPTION
## Summary

Make sure aztec is initialized when document is ready.

## Description

In sdk's entry point, we initialize aztec and assign the instance to `window.aztec` when document is ready, i.e.: when `DOMContentLoaded` is fired. This works fine if the sdk script tag is included in the initial html file.

But if the sdk is added to the html after the webpage is loaded. The event will not be triggered again and aztec will never be initialized. So we should also initialize aztec when the `document.readyState` variable is either _interactive_ or _interactive_.

## Types of changes

Bug fix (non-breaking change which fixes an issue)
