### PR TITLE
Sdk installer

### DIFF
--- a/packages/sdk-installer/.eslintignore
+++ b/packages/sdk-installer/.eslintignore
@@ -1,0 +1,3 @@
+# ignored directories
+node_modules/*
+/dist/*

--- a/packages/sdk-installer/.eslintrc.js
+++ b/packages/sdk-installer/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+    extends: 'airbnb/base',
+    parser: 'babel-eslint',
+    env: {
+        browser: true,
+        es6: true,
+        node: true,
+        jest: true,
+    },
+    rules: {
+        indent: [
+            'error',
+            4,
+            {
+                SwitchCase: 1,
+            },
+        ],
+    },
+};

--- a/packages/sdk-installer/README.md
+++ b/packages/sdk-installer/README.md
@@ -1,0 +1,48 @@
+# AZTEC SDK Installer
+
+This is a simple npm package that helps you setup AZTEC in your project.
+
+### Install
+
+```sh
+yarn add @aztec/sdk-installer
+```
+
+or
+
+```sh
+npm install @aztec/sdk-installer
+```
+
+### Getting started
+
+When you import installer to your code, the installer will add a script tag to the html. The content of the SDK will start loading at this point and might not be available immediately. So you will also need to provide a callback to the installer. The callback will be triggered once the SDK is ready to use.
+
+```js
+import installer from '@aztec/sdk-installer';
+
+const startUsingAztec = () => {};
+
+installer.onLoad(startUsingAztec);
+```
+
+_** Note that the webpage will fetch the SDK with the same version as the installer. So upgrade the installer regularly to get the latest version of the SDK._
+
+
+### Using the SDK
+
+Once the SDK is loaded, you can access `aztec` by:
+
+```js
+await window.aztec.enable();
+```
+
+or
+
+```js
+import installer from '@aztec/sdk-installer';
+await installer.aztec.enable();
+```
+
+#### For the full AZTEC SDK usage
+Checkout the docs here: **[https://docs.aztecprotocol.com/](https://docs.aztecprotocol.com/)**

--- a/packages/sdk-installer/README.md
+++ b/packages/sdk-installer/README.md
@@ -26,8 +26,7 @@ const startUsingAztec = () => {};
 installer.onLoad(startUsingAztec);
 ```
 
-_** Note that the webpage will fetch the SDK with the same version as the installer. So upgrade the installer regularly to get the latest version of the SDK._
-
+_\*\* Note that the webpage will fetch the SDK with the same version as the installer. So upgrade the installer regularly to get the latest version of the SDK._
 
 ### Using the SDK
 
@@ -45,4 +44,5 @@ await installer.aztec.enable();
 ```
 
 #### For the full AZTEC SDK usage
+
 Checkout the docs here: **[https://docs.aztecprotocol.com/](https://docs.aztecprotocol.com/)**

--- a/packages/sdk-installer/babel.config.js
+++ b/packages/sdk-installer/babel.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+    presets: [
+        '@babel/preset-env',
+    ],
+    plugins: [
+        '@babel/plugin-proposal-class-properties',
+        '@babel/plugin-proposal-object-rest-spread',
+    ],
+    env: {
+        transpile: {
+            presets: [
+                '@babel/preset-env',
+            ],
+            plugins: [
+                '@babel/plugin-proposal-class-properties',
+                '@babel/plugin-proposal-object-rest-spread',
+            ],
+        },
+    },
+};

--- a/packages/sdk-installer/babel.config.js
+++ b/packages/sdk-installer/babel.config.js
@@ -1,20 +1,10 @@
 module.exports = {
-    presets: [
-        '@babel/preset-env',
-    ],
-    plugins: [
-        '@babel/plugin-proposal-class-properties',
-        '@babel/plugin-proposal-object-rest-spread',
-    ],
+    presets: ['@babel/preset-env'],
+    plugins: ['@babel/plugin-proposal-class-properties', '@babel/plugin-proposal-object-rest-spread'],
     env: {
         transpile: {
-            presets: [
-                '@babel/preset-env',
-            ],
-            plugins: [
-                '@babel/plugin-proposal-class-properties',
-                '@babel/plugin-proposal-object-rest-spread',
-            ],
+            presets: ['@babel/preset-env'],
+            plugins: ['@babel/plugin-proposal-class-properties', '@babel/plugin-proposal-object-rest-spread'],
         },
     },
 };

--- a/packages/sdk-installer/package.json
+++ b/packages/sdk-installer/package.json
@@ -1,0 +1,32 @@
+{
+    "name": "@aztec/sdk-installer",
+    "description": "NPM package for AZTEC SDK",
+    "license": "LGPL-3.0",
+    "version": "1.10.1",
+    "author": "AZTEC",
+    "bugs": {
+        "url": "https://github.com/AztecProtocol/AZTEC/issues"
+    },
+    "main": "dist/installer.js",
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "yarn transpile",
+        "lint": "eslint ./ --color",
+        "test": "jest ./tests",
+        "transpile": "BABEL_ENV=transpile babel src -d dist"
+    },
+    "devDependencies": {
+        "@babel/cli": "^7.2.3",
+        "@babel/core": "^7.4.0",
+        "@babel/node": "^7.2.2",
+        "@babel/plugin-proposal-class-properties": "^7.4.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+        "@babel/preset-env": "^7.4.4",
+        "babel-eslint": "^10.0.2",
+        "eslint": "^6.8.0",
+        "eslint-config-airbnb-base": "^14.1.0",
+        "jest": "^25.1.0"
+    }
+}

--- a/packages/sdk-installer/src/InstallManager.js
+++ b/packages/sdk-installer/src/InstallManager.js
@@ -1,0 +1,59 @@
+export default class InstallerManager {
+    constructor(version) {
+        this.version = version;
+        this.scriptId = 'aztec-sdk-script';
+        this.onLoadListeners = new Set();
+
+        this.init();
+    }
+
+    init() {
+        if (window.aztec) return;
+
+        if (window.aztecCallback) {
+            this.onLoadListeners.add(window.aztecCallback);
+        }
+        window.aztecCallback = this.handleAztecLoaded;
+
+        const readyStates = [
+            'complete',
+            'interactive',
+        ];
+
+        if (readyStates.indexOf(document.readyState) >= 0) {
+            this.addSdkScript();
+        } else {
+            document.addEventListener('DOMContentLoaded', () => {
+                this.addSdkScript();
+            });
+        }
+    }
+
+    addSdkScript() {
+        const prevScript = document.getElementById(this.scriptId);
+        if (prevScript) return;
+
+        const script = document.createElement('script');
+        script.id = this.scriptId;
+        script.type = 'module';
+        script.src = `https://sdk.aztecprotocol.com/${this.version}/sdk/aztec.js`;
+        document.body.appendChild(script);
+    }
+
+    handleAztecLoaded = () => {
+        if (!this.onLoadListeners) return;
+
+        this.onLoadListeners.forEach((cb) => {
+            cb();
+        });
+        this.onLoadListeners = null;
+    };
+
+    onLoad(cb) {
+        if (window.aztec) {
+            cb();
+        } else {
+            this.onLoadListeners.add(cb);
+        }
+    }
+}

--- a/packages/sdk-installer/src/InstallManager.js
+++ b/packages/sdk-installer/src/InstallManager.js
@@ -15,10 +15,7 @@ export default class InstallerManager {
         }
         window.aztecCallback = this.handleAztecLoaded;
 
-        const readyStates = [
-            'complete',
-            'interactive',
-        ];
+        const readyStates = ['complete', 'interactive'];
 
         if (readyStates.indexOf(document.readyState) >= 0) {
             this.addSdkScript();

--- a/packages/sdk-installer/src/installer.js
+++ b/packages/sdk-installer/src/installer.js
@@ -1,0 +1,38 @@
+import json from '../package.json';
+import InstallManager from './InstallManager';
+
+let manager = null;
+
+class AztecSdkInstaller {
+    constructor() {
+        if (typeof window === 'undefined') {
+            console.error('AZTEC SDK can only be run in web browser.'); // eslint-disable-line no-console
+            return;
+        }
+
+        this.version = json.version;
+        this.aztec = null;
+
+        manager = new InstallManager(this.version);
+
+        manager.onLoad(() => {
+            this.aztec = window.aztec;
+        });
+
+        if (process.env.NODE_ENV === 'test') {
+            this.manager = manager;
+        }
+    }
+
+    onLoad(cb) { // eslint-disable-line class-methods-use-this
+        manager.onLoad(cb);
+    }
+}
+
+const SdkInstaller = process.env.NODE_ENV === 'test' ? AztecSdkInstaller : null;
+
+export {
+    SdkInstaller,
+};
+
+export default new AztecSdkInstaller();

--- a/packages/sdk-installer/src/installer.js
+++ b/packages/sdk-installer/src/installer.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import json from '../package.json';
 import InstallManager from './InstallManager';
 
@@ -24,15 +25,13 @@ class AztecSdkInstaller {
         }
     }
 
-    onLoad(cb) { // eslint-disable-line class-methods-use-this
+    onLoad(cb) {
         manager.onLoad(cb);
     }
 }
 
 const SdkInstaller = process.env.NODE_ENV === 'test' ? AztecSdkInstaller : null;
 
-export {
-    SdkInstaller,
-};
+export { SdkInstaller };
 
 export default new AztecSdkInstaller();

--- a/packages/sdk-installer/tests/env-node.test.js
+++ b/packages/sdk-installer/tests/env-node.test.js
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment node
+ */
+
+const importInstaller = () => require('../src/installer.js').default; // eslint-disable-line global-require
+
+describe('installer', () => {
+    it('log error if window is not defined', () => {
+        const errors = [];
+        const errorLogMock = jest.spyOn(console, 'error')
+            .mockImplementation((error) => {
+                errors.push(error);
+            });
+
+        importInstaller();
+        expect(errors).toEqual(['AZTEC SDK can only be run in web browser.']);
+
+        errorLogMock.mockRestore();
+    });
+});

--- a/packages/sdk-installer/tests/env-node.test.js
+++ b/packages/sdk-installer/tests/env-node.test.js
@@ -7,10 +7,9 @@ const importInstaller = () => require('../src/installer.js').default; // eslint-
 describe('installer', () => {
     it('log error if window is not defined', () => {
         const errors = [];
-        const errorLogMock = jest.spyOn(console, 'error')
-            .mockImplementation((error) => {
-                errors.push(error);
-            });
+        const errorLogMock = jest.spyOn(console, 'error').mockImplementation((error) => {
+            errors.push(error);
+        });
 
         importInstaller();
         expect(errors).toEqual(['AZTEC SDK can only be run in web browser.']);

--- a/packages/sdk-installer/tests/installer.test.js
+++ b/packages/sdk-installer/tests/installer.test.js
@@ -1,6 +1,4 @@
-import aztecSdkInsterller, {
-    SdkInstaller,
-} from '../src/installer';
+import aztecSdkInsterller, { SdkInstaller } from '../src/installer';
 import json from '../package.json';
 
 const { scriptId } = aztecSdkInsterller.manager;

--- a/packages/sdk-installer/tests/installer.test.js
+++ b/packages/sdk-installer/tests/installer.test.js
@@ -1,0 +1,122 @@
+import aztecSdkInsterller, {
+    SdkInstaller,
+} from '../src/installer';
+import json from '../package.json';
+
+const { scriptId } = aztecSdkInsterller.manager;
+
+const mockSdkLoaded = () => {
+    window.aztec = {};
+    window.aztecCallback();
+};
+
+beforeEach(() => {
+    window.aztec = null;
+    window.aztecCallback = null;
+    document.body.innerHTML = '';
+});
+
+describe('installer constructor', () => {
+    it('has the same version as defined in package.json', () => {
+        const installer = new SdkInstaller();
+        expect(installer.version).toBe(json.version);
+    });
+
+    it('append a script tag to body', () => {
+        const prevScript = document.getElementById(scriptId);
+        expect(prevScript).toBe(null);
+
+        const installer = new SdkInstaller();
+
+        const script = document.getElementById(scriptId);
+        expect(script).not.toBe(null);
+        expect(script.type).toBe('module');
+        expect(script.src).toContain(installer.version);
+    });
+
+    it('will not append another script tag if it is already in body', () => {
+        const appendChildSpy = jest.spyOn(document.body, 'appendChild');
+        expect(appendChildSpy).toHaveBeenCalledTimes(0);
+
+        const installer = new SdkInstaller();
+
+        expect(appendChildSpy).toHaveBeenCalledTimes(1);
+        const script = document.getElementById(scriptId);
+        expect(script).not.toBe(null);
+        expect(script.src).toContain(installer.version);
+
+        const installer2 = new SdkInstaller();
+
+        expect(appendChildSpy).toHaveBeenCalledTimes(1);
+        expect(installer2).not.toBe(installer);
+        const script2 = document.getElementById(scriptId);
+        expect(script).toBe(script2);
+    });
+
+    it('will not append script tag before document is ready', () => {
+        Object.defineProperty(document, 'readyState', {
+            get: jest.fn(() => 'loading'),
+        });
+
+        const appendChildSpy = jest.spyOn(document.body, 'appendChild');
+        appendChildSpy.mockReset();
+
+        const installer = new SdkInstaller();
+
+        const addSdkScriptSpy = jest.spyOn(installer.manager, 'addSdkScript');
+
+        expect(appendChildSpy).toHaveBeenCalledTimes(0);
+        const script = document.getElementById(scriptId);
+        expect(script).toBe(null);
+        expect(addSdkScriptSpy).toHaveBeenCalledTimes(0);
+
+        const event = document.createEvent('Event');
+        event.initEvent('DOMContentLoaded', true, true);
+        window.document.dispatchEvent(event);
+
+        expect(appendChildSpy).toHaveBeenCalledTimes(1);
+        expect(addSdkScriptSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('trigger callbacks when sdk is loaded', () => {
+        const cb1 = jest.fn();
+        const cb2 = jest.fn();
+
+        const installer = new SdkInstaller();
+        installer.onLoad(cb1);
+        installer.onLoad(cb2);
+
+        expect(cb1).toHaveBeenCalledTimes(0);
+        expect(cb2).toHaveBeenCalledTimes(0);
+
+        mockSdkLoaded();
+
+        expect(cb1).toHaveBeenCalledTimes(1);
+        expect(cb2).toHaveBeenCalledTimes(1);
+    });
+
+    it('callbacks will be triggered immediately when sdk is loaded', () => {
+        const installer = new SdkInstaller();
+
+        mockSdkLoaded();
+
+        const cb = jest.fn();
+        installer.onLoad(cb);
+        expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('the same callbacks will be triggered only once', () => {
+        const cb = jest.fn();
+
+        const installer = new SdkInstaller();
+
+        installer.onLoad(cb);
+        installer.onLoad(cb);
+
+        expect(cb).toHaveBeenCalledTimes(0);
+
+        mockSdkLoaded();
+
+        expect(cb).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Summary

Add a new package `sdk-installer` to let developers integrate sdk into their apps by importing a npm package.

## Description

The installer will add a script tag to the html with this format:
`https://sdk.aztecprotocol.com/${version}/sdk/aztec.js`
`version` is defined in `package.json` and should be updated correspond to the version of sdk.

It also provides a `.onLoad` api to handle listeners, which will be triggers after sdk is loaded and the aztec instance assigned to `window.aztec`.

_The code for the installer is separated from `packages/sdk` because we don't need any dependencies to install it. If it is shipped within `packages/sdk`, users will end up installing all the unnecessary dependencies defined in sdk's package.json._

## Testing instructions

In packages/sdk-installer, run:

```bash
yarn test
```

## Types of changes

New feature (non-breaking change which adds functionality) 
