### PR TITLE
Always add user's own access when creating note from the api

### DIFF
--- a/packages/extension/src/client/apis/Account.js
+++ b/packages/extension/src/client/apis/Account.js
@@ -51,7 +51,7 @@ class Account {
                 'users',
                 {
                     where: {
-                        address_in: uniq(userAccess),
+                        address_in: uniq(userAccess).filter(a => a !== this.address),
                     },
                 },
                 `
@@ -60,6 +60,10 @@ class Account {
                 `,
             ) || {});
         }
+        noteAccess.push({
+            address: this.address,
+            linkedPublicKey: this.linkedPublicKey,
+        });
 
         return noteUtils.create(
             this.spendingPublicKey,


### PR DESCRIPTION
## Summary

An AZTEC note generated from sdk's `user.createNote` api will always include the user's address and linkedPublicKey to the metaData.

## Types of changes

Bug fix (non-breaking change which fixes an issue) 
