### PR TITLE
fix(aztec.js): fix node build

### DIFF
--- a/packages/aztec.js/src/note/index.js
+++ b/packages/aztec.js/src/note/index.js
@@ -311,8 +311,8 @@ export async function fromEventLog(logNoteData, spendingKey = null) {
     const newNote = new Note(notePublicKey, null);
     if (spendingKey) {
         await newNote.derive(spendingKey);
-        const { publicKey } = secp256k1.accountFromPrivateKey(spendingKey);
-        newNote.owner = publicKey;
+        const { address } = secp256k1.accountFromPrivateKey(spendingKey);
+        newNote.owner = address;
     }
     return newNote;
 }

--- a/packages/aztec.js/src/note/index.js
+++ b/packages/aztec.js/src/note/index.js
@@ -307,10 +307,12 @@ export function encodeMetadata(noteArray) {
  * @returns {Note} created note instance
  */
 export async function fromEventLog(logNoteData, spendingKey = null) {
-    const publicKey = noteCoder.decodeNoteFromEventLog(logNoteData);
-    const newNote = new Note(publicKey, null);
+    const notePublicKey = noteCoder.decodeNoteFromEventLog(logNoteData);
+    const newNote = new Note(notePublicKey, null);
     if (spendingKey) {
         await newNote.derive(spendingKey);
+        const { publicKey } = secp256k1.accountFromPrivateKey(spendingKey);
+        newNote.owner = publicKey;
     }
     return newNote;
 }

--- a/packages/aztec.js/webpack.common.js
+++ b/packages/aztec.js/webpack.common.js
@@ -37,7 +37,4 @@ module.exports = {
         maxAssetSize: 200000,
         maxEntrypointSize: 400000,
     },
-    resolve: {
-        extensions: ['.js', '.json'],
-    },
 };

--- a/packages/aztec.js/webpack.dev.js
+++ b/packages/aztec.js/webpack.dev.js
@@ -1,4 +1,6 @@
 const merge = require('webpack-merge');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+
 const common = require('./webpack.common.js');
 
 const config = {
@@ -14,6 +16,17 @@ const nodeConfig = merge(common, {
     },
     output: { filename: 'bundle.node.js' },
     target: 'node',
+    plugins: [
+        new CopyWebpackPlugin([
+            {
+                from: 'node_modules/@aztec/bn128/**/*.wasm',
+                to: '[name].[ext]',
+            },
+        ]),
+    ],
+    resolve: {
+        extensions: ['.js', '.json', '.wasm'],
+    },
 });
 
 const webConfig = merge(common, {
@@ -21,6 +34,9 @@ const webConfig = merge(common, {
     node: { crypto: true, fs: 'empty' },
     output: { filename: 'bundle.web.js' },
     target: 'web',
+    resolve: {
+        extensions: ['.js', '.json'],
+    },
 });
 
 module.exports = [nodeConfig, webConfig];

--- a/packages/aztec.js/webpack.prod.js
+++ b/packages/aztec.js/webpack.prod.js
@@ -1,9 +1,10 @@
 const merge = require('webpack-merge');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const common = require('./webpack.common.js');
 
 const config = {
     mode: 'production',
-    devtool: '',
+    devtool: 'inline-source-map',
 };
 
 const nodeConfig = merge(common, {
@@ -14,6 +15,17 @@ const nodeConfig = merge(common, {
     },
     output: { filename: 'bundle.node.js' },
     target: 'node',
+    plugins: [
+        new CopyWebpackPlugin([
+            {
+                from: 'node_modules/@aztec/bn128/**/*.wasm',
+                to: '[name].[ext]',
+            },
+        ]),
+    ],
+    resolve: {
+        extensions: ['.js', '.json', '.wasm'],
+    },
 });
 
 const webConfig = merge(common, {
@@ -21,6 +33,9 @@ const webConfig = merge(common, {
     node: { crypto: true, fs: 'empty' },
     output: { filename: 'bundle.web.js' },
     target: 'web',
+    resolve: {
+        extensions: ['.js', '.json'],
+    },
 });
 
 module.exports = [nodeConfig, webConfig];


### PR DESCRIPTION
## Summary

Fixes #536 and #535. Explicitly includes `mcl.wasm` in node build of `aztec.js`, and populates owner field of notes recovered from event logs.

## Testing instructions

`yarn test`

## Types of changes

* Bug fix (non-breaking change which fixes an issue)